### PR TITLE
fix : jwt token import method error fix

### DIFF
--- a/text_filtering/text_filtering.py
+++ b/text_filtering/text_filtering.py
@@ -82,7 +82,7 @@ def contains_english_profanity(text: str) -> bool:
     return any(bad_word in lower_text for bad_word in ENGLISH_BAD_WORDS)
 
 def predict(text: str) -> Tuple[int, str]:
-    encoded = tokenizer.encode_plus(
+    encoded = tokenizer(
         text,
         add_special_tokens=True,
         max_length=64,

--- a/text_filtering/text_filtering.py
+++ b/text_filtering/text_filtering.py
@@ -4,11 +4,8 @@ from pydantic import BaseModel
 from transformers import ElectraTokenizer, ElectraForSequenceClassification
 from jose import JWTError, jwt
 from dotenv import load_dotenv
-import torch
-import os
-import re
+import torch, os, re, base64
 from typing import Tuple, List, Dict
-import base64
 from jose.exceptions import ExpiredSignatureError
 
 load_dotenv()
@@ -77,9 +74,11 @@ def split_sentences(text: str) -> List[str]:
         text = re.sub(rf'({end})(?=\s)', r'\1\n', text)
     return [s.strip() for s in text.split('\n') if s.strip()]
 
+
 def contains_english_profanity(text: str) -> bool:
     lower_text = text.lower()
     return any(bad_word in lower_text for bad_word in ENGLISH_BAD_WORDS)
+
 
 def predict(text: str) -> Tuple[int, str]:
     encoded = tokenizer(
@@ -126,7 +125,7 @@ def analyze_field(field_name: str, text: str, log_file) -> Dict:
 
 
 @router.post("/text_filter_board")
-async def text_filter_board_api(request: Request, payload: TextRequest, username: str = Depends(verify_jwt_token)):
+async def text_filter_board_api(payload: TextRequest, username: str = Depends(verify_jwt_token)):
     try:
         full_text = payload.text.strip()
         try:
@@ -157,7 +156,7 @@ async def text_filter_board_api(request: Request, payload: TextRequest, username
 
 
 @router.post("/text_filter_market")
-async def text_filter_market_api(request: Request, payload: TextRequest, username: str = Depends(verify_jwt_token)):
+async def text_filter_market_api(payload: TextRequest, username: str = Depends(verify_jwt_token)):
     try:
         full_text = payload.text.strip()
         try:

--- a/text_filtering/text_filtering_rule.py
+++ b/text_filtering/text_filtering_rule.py
@@ -3,12 +3,9 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from transformers import ElectraTokenizer, ElectraForSequenceClassification
 from jose import JWTError, jwt
-import torch
-import os
+import torch, os, re, base64
 from typing import Tuple, List, Dict
-import re
 from dotenv import load_dotenv
-import base64
 from jose.exceptions import ExpiredSignatureError
 
 load_dotenv()
@@ -132,7 +129,6 @@ def analyze_field(field_name: str, text: str, log_file=None) -> Dict:
 
 @router.post("/text_filter_rule")
 async def rule_filter_api(
-    request: Request,
     payload: TextRequest,
     username: str = Depends(verify_jwt_token)
 ):

--- a/text_filtering/text_filtering_rule.py
+++ b/text_filtering/text_filtering_rule.py
@@ -84,7 +84,7 @@ def contains_english_profanity(text: str) -> bool:
 
 
 def predict(text: str) -> Tuple[int, str]:
-    encoded = tokenizer.encode_plus(
+    encoded = tokenizer(
         text,
         add_special_tokens=True,
         max_length=64,


### PR DESCRIPTION
## 📌 텍스트 필터링 JWT 인증 오류


### 📝 작업 내용
- jwt tokenizer predict 함수 수정
- 범용적으로 사용중인 현재 표준인 tokenizer로 수정
   - tokenizer.encode_plus -> tokenizer 로 수정


### ✅ 체크리스트
- [x] 불필요한 주석/코드를 제거
- [x] 로컬 환경에서 정상 동작

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- 변경 요약(1~3줄)
토크나이저 호출을 Hugging Face 최신 표준(tokenizer(...))으로 대체했고, 일부 텍스트 필터 API들의 함수 시그니처에서 Request 파라미터를 제거하는 등 경량 리팩터링을 진행했습니다.

- 주요 변경점
- predict 함수의 tokenizer.encode_plus(...)를 tokenizer(...) 호출로 변경(매개변수 유지: add_special_tokens, max_length, padding, truncation, return_tensors).
- text_filtering.py, text_filtering_rule.py 전반에서 불필요한 import/코드 정리 및 포맷팅 정리.
- API 시그니처 변경: text_filter_board_api, text_filter_market_api, rule_filter_api 등에서 Request 파라미터 제거(이제 payload: TextRequest, username: Depends(verify_jwt_token) 형태).
- analyze_field 시그니처와 내부 변수 일부 변경(옵션 로그 파일 인자 기본값 추가 및 로그 작성 조건 조정).
- JWT 검증 로직(verify_jwt_token)은 유지되며 토큰 추출/검증 방식은 그대로임.

- 주의/리스크
- Transformers 버전 호환성: 구버전에서는 tokenizer(...) 시그니처가 다를 수 있어 호환성 확인 필요.
- API 시그니처 변경으로 기존 호출(특히 Request 객체를 직접 넘기던 내부/외부 호출)이 실패할 수 있음 — 호출자 영향도 점검 필요.

- 다음 액션
- 통합 테스트 및 기존 클라이언트/엔드포인트 호출 경로(특히 Request 사용 여부) 검증.
- CI/스테이징에서 토크나이저 동작(입력/attention mask 생성) 및 JWT 인증 흐름 재검증.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->