### PR TITLE
feat : 시간표 분석 비동기 처리 구현

### DIFF
--- a/image_analysis/timetable_analysis.py
+++ b/image_analysis/timetable_analysis.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, UploadFile, File, HTTPException, Request
 from fastapi.responses import Response, JSONResponse
 import cv2, re, numpy as np
 from PIL import Image
-import os, asyncio, uuid, pytesseract, base64
+import os, asyncio, uuid, pytesseract, base64, httpx
 from concurrent.futures import ThreadPoolExecutor
 from jose import JWTError, jwt
 from dotenv import load_dotenv
@@ -17,6 +17,7 @@ load_dotenv()
 
 SECRET_KEY = os.getenv("SECRET_KEY")
 ALGORITHM = os.getenv("ALGORITHM")
+SPRING_TIMETABLE_URL = os.getenv("SPRING_TIMETABLE_URL")
 
 WEEKDAYS_FILE = "data/weekdays.txt"
 TIME_SLOTS_FILE = "data/time_slots.txt"
@@ -56,6 +57,7 @@ class JobStatus(str, Enum):
     ERROR   = "error"
 
 _job_store: Dict[str, Dict[str, Any]] = {}
+_active_users: set = set()
 _job_queue: asyncio.Queue = asyncio.Queue(maxsize=20)
 _WORKER_CONCURRENCY = 2
 _THREAD_EXECUTOR = ThreadPoolExecutor(max_workers=2)
@@ -71,12 +73,38 @@ def _cleanup_old_jobs():
         _job_store.pop(job_id, None)
 
 
+async def _post_to_spring(user_id: str, job_id: str, schedules: List[dict], token: str):
+    now = datetime.now(timezone.utc)
+    month = now.month
+    year = now.year
+    semester = "FIRST" if 3 <= month <= 8 else "SECOND"
+
+    payload = [
+        {
+            "name":      item["name"],
+            "professor": item.get("professor", ""),
+            "location":  item.get("location", ""),
+            "week":      item["week"],
+            "startAt":   item["startAt"],
+            "endAt":     item["endAt"],
+            "year":      year,
+            "semester":  semester,
+        }
+        for item in schedules
+    ]
+
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        await client.post(SPRING_TIMETABLE_URL, json=payload, headers=headers)
+
+
 async def _queue_worker():
     loop = asyncio.get_running_loop()
     while True:
-        job_id, img = await _job_queue.get()
+        job_id, user_id, img, token = await _job_queue.get()
         job = _job_store.get(job_id)
         if job is None:
+            _active_users.discard(user_id)
             _job_queue.task_done()
             continue
         job["status"] = JobStatus.RUNNING
@@ -85,12 +113,14 @@ async def _queue_worker():
                 _THREAD_EXECUTOR, extract_schedule_fixed_scaled, img
             )
             job["status"] = JobStatus.DONE
-            job["result"] = result
+            if result:
+                await _post_to_spring(user_id, job_id, result, token)
         except Exception as exc:
             job["status"] = JobStatus.ERROR
             job["error"]  = str(exc)
         finally:
-            job["event"].set()
+            _active_users.discard(user_id)
+            _job_store.pop(job_id, None)
             _job_queue.task_done()
             _cleanup_old_jobs()
 
@@ -473,7 +503,12 @@ def verify_jwt_token(request: Request):
 
 @router.post("/timetable_analysis")
 async def upload_timetable(request: Request, file: UploadFile = File(...)):
-    _ = verify_jwt_token(request)
+    user_id = verify_jwt_token(request)
+
+    # 동일 유저 중복 분석 방지
+    if user_id in _active_users:
+        return JSONResponse(status_code=503, content={"error": "Already processing"})
+
     try:
         file_bytes = await file.read()
         npimg = np.frombuffer(file_bytes, np.uint8)
@@ -482,46 +517,23 @@ async def upload_timetable(request: Request, file: UploadFile = File(...)):
         if img is None:
             return JSONResponse(status_code=400, content={"error": "Invalid image format"})
 
+        token = request.headers.get("Authorization", "").split(" ")[1]
         job_id = str(uuid.uuid4())
         _job_store[job_id] = {
             "status":     JobStatus.PENDING,
-            "result":     None,
-            "error":      None,
-            "event":      asyncio.Event(),
             "created_at": datetime.now(timezone.utc),
         }
+        _active_users.add(user_id)
+
         try:
-            await asyncio.wait_for(_job_queue.put((job_id, img)), timeout=30.0)
+            await asyncio.wait_for(_job_queue.put((job_id, user_id, img, token)), timeout=10.0)
         except asyncio.TimeoutError:
             _job_store.pop(job_id, None)
-            return JSONResponse(status_code=503, content={"error": "server is busy"})
+            _active_users.discard(user_id)
+            return JSONResponse(status_code=504, content={"error": "Server is busy"})
 
-        return JSONResponse(status_code=202, content={"job_id": job_id})
+        return JSONResponse(status_code=204, content={"job_id": job_id})
 
     except Exception as e:
+        _active_users.discard(user_id)
         return JSONResponse(status_code=500, content={"error": str(e)})
-
-
-@router.get("/timetable_result/{job_id}")
-async def get_timetable_result(job_id: str, request: Request):
-    _ = verify_jwt_token(request)
-
-    job = _job_store.get(job_id)
-    if job is None:
-        raise HTTPException(status_code=404, detail="job not found")
-
-    try:
-        await asyncio.wait_for(job["event"].wait(), timeout=120.0)
-    except asyncio.TimeoutError:
-        _job_store.pop(job_id, None)
-        return JSONResponse(status_code=504, content={"error": "Processing timeout"})
-
-    if job["status"] == JobStatus.ERROR:
-        _job_store.pop(job_id, None)
-        return JSONResponse(status_code=500, content={"error": job["error"]})
-
-    result = job["result"]
-    _job_store.pop(job_id, None)
-    if not result:
-        return Response(status_code=204)
-    return JSONResponse(content=result)

--- a/image_analysis/timetable_analysis.py
+++ b/image_analysis/timetable_analysis.py
@@ -508,6 +508,7 @@ async def upload_timetable(request: Request, file: UploadFile = File(...)):
     # 동일 유저 중복 분석 방지
     if user_id in _active_users:
         return JSONResponse(status_code=503, content={"error": "Already processing"})
+    _active_users.add(user_id)
 
     try:
         file_bytes = await file.read()
@@ -515,6 +516,7 @@ async def upload_timetable(request: Request, file: UploadFile = File(...)):
         img = cv2.imdecode(npimg, cv2.IMREAD_COLOR)
 
         if img is None:
+            _active_users.discard(user_id)
             return JSONResponse(status_code=400, content={"error": "Invalid image format"})
 
         token = request.headers.get("Authorization", "").split(" ")[1]
@@ -523,7 +525,6 @@ async def upload_timetable(request: Request, file: UploadFile = File(...)):
             "status":     JobStatus.PENDING,
             "created_at": datetime.now(timezone.utc),
         }
-        _active_users.add(user_id)
 
         try:
             await asyncio.wait_for(_job_queue.put((job_id, user_id, img, token)), timeout=10.0)

--- a/image_analysis/timetable_analysis.py
+++ b/image_analysis/timetable_analysis.py
@@ -532,8 +532,8 @@ async def upload_timetable(request: Request, file: UploadFile = File(...)):
             _active_users.discard(user_id)
             return JSONResponse(status_code=504, content={"error": "Server is busy"})
 
-        return JSONResponse(status_code=204, content={"job_id": job_id})
+        return JSONResponse(status_code=202, content={"job_id": job_id})
 
-    except Exception as e:
+    except Exception:
         _active_users.discard(user_id)
-        return JSONResponse(status_code=500, content={"error": str(e)})
+        return JSONResponse(status_code=500, content={"error": "Internal server error"})


### PR DESCRIPTION
# 관련 이슈

Close #80 

## 🎯 배경
시간표 분석 시 클라이언트 요청 대기시간이 너무 오래걸리는 현상이 발생 -> 특정 시간 초과 시 timeout 현상 및 연결 끊겼을 때 작업하던 리소스에 대한 낭비가 발생합니다.
이를 해결하기 위해 클라이언트 요청에 작업 시작에 대한 결과만 반환 후 백그라운드 Queue에서 작업 후 Spring 서버에 요청을 따로 보내는 것으로 나눴습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- 변경 요약(1~3줄)
클라이언트의 시간표 분석을 비동기로 전환했습니다. 서버는 즉시 작업 시작 응답을 반환하고, 백그라운드 워커가 분석 완료 후 Spring 서버로 결과를 POST합니다.

- 주요 변경점
- HTTPX 통합: `_post_to_spring()` 추가로 SPRING_TIMETABLE_URL에 Bearer 토큰으로 결과 전송
- 사용자별 동시성 제어: `_active_users` 집합으로 동일 사용자에 대한 중복 분석 차단
- 큐 페이로드 확장: (job_id, user_id, img, token) 형태로 토큰·사용자 정보 포함
- 요청 흐름 변경: 업로드 처리 시 즉시 작업 수락(비동기), 기존 `timetable_result` 엔드포인트/폴링 방식 제거
- 오류·응답 처리 조정: 서버 바쁨은 504 반환, 내부 에러는 500으로 통일, 예외 시 active user 정리 보장

- 주의/리스크
- HTTPX 의존성 및 환경변수(SPRING_TIMETABLE_URL) 관리 필요
- Spring으로 전송 실패 시 재시도/백오프 정책 미비(현재 동작 확인 필요)
- JWT 토큰에서 추출한 user_id 및 토큰 전달의 보안·검증 로직 재검토 필요

- 다음 액션
- CI/배포에 HTTPX 패키지 및 환경변수 반영 확인
- Spring 타깃 엔드포인트와 인증 연동·통합 테스트 수행
- 전송 실패 시 재시도·알림 정책(로그/재시도 전략) 설계 및 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->