### PR TITLE
fix: timetable automatic registration error

### DIFF
--- a/image_analysis/timetable_analysis.py
+++ b/image_analysis/timetable_analysis.py
@@ -112,16 +112,17 @@ async def _queue_worker():
             result = await loop.run_in_executor(
                 _THREAD_EXECUTOR, extract_schedule_fixed_scaled, img
             )
-            job["status"] = JobStatus.DONE
-            print(f"[Worker DONE] job_id={job_id}, user_id={user_id}, result_count={len(result) if result else 0}")
             if result:
                 await _post_to_spring(user_id, job_id, result, token, appcheck_token)
+                job["status"] = JobStatus.DONE
+                print(f"[Worker DONE] job_id={job_id}, result_count={len(result) if result else 0}")
             else:
+                job["status"] = JobStatus.DONE
                 print(f"[Worker] OCR result is empty, skipping Spring POST")
         except Exception as exc:
             job["status"] = JobStatus.ERROR
             job["error"]  = str(exc)
-            print(f"[Worker ERROR] job_id={job_id}, user_id={user_id}, error={exc}")
+            print(f"[Worker ERROR] job_id={job_id}, error={exc}")
         finally:
             _active_users.discard(user_id)
             _job_store.pop(job_id, None)

--- a/image_analysis/timetable_analysis.py
+++ b/image_analysis/timetable_analysis.py
@@ -95,7 +95,8 @@ async def _post_to_spring(user_id: str, job_id: str, schedules: List[dict], toke
 
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json", "X-Firebase-AppCheck": appcheck_token}
     async with httpx.AsyncClient(timeout=10.0) as client:
-        await client.post(SPRING_TIMETABLE_URL, json=payload, headers=headers)
+        response = await client.post(SPRING_TIMETABLE_URL, json=payload, headers=headers)
+        response.raise_for_status()
 
 
 async def _queue_worker():
@@ -118,7 +119,7 @@ async def _queue_worker():
                 print(f"[Worker DONE] job_id={job_id}, result_count={len(result) if result else 0}")
             else:
                 job["status"] = JobStatus.DONE
-                print(f"[Worker] OCR result is empty, skipping Spring POST")
+                print(f"[Worker DONE] job_id={job_id}, result_count=0, spring_post=skipped")
         except Exception as exc:
             job["status"] = JobStatus.ERROR
             job["error"]  = str(exc)

--- a/image_analysis/timetable_analysis.py
+++ b/image_analysis/timetable_analysis.py
@@ -113,11 +113,15 @@ async def _queue_worker():
                 _THREAD_EXECUTOR, extract_schedule_fixed_scaled, img
             )
             job["status"] = JobStatus.DONE
+            print(f"[Worker DONE] job_id={job_id}, user_id={user_id}, result_count={len(result) if result else 0}")
             if result:
                 await _post_to_spring(user_id, job_id, result, token)
+            else:
+                print(f"[Worker] OCR result is empty, skipping Spring POST")
         except Exception as exc:
             job["status"] = JobStatus.ERROR
             job["error"]  = str(exc)
+            print(f"[Worker ERROR] job_id={job_id}, user_id={user_id}, error={exc}")
         finally:
             _active_users.discard(user_id)
             _job_store.pop(job_id, None)

--- a/image_analysis/timetable_analysis.py
+++ b/image_analysis/timetable_analysis.py
@@ -73,7 +73,7 @@ def _cleanup_old_jobs():
         _job_store.pop(job_id, None)
 
 
-async def _post_to_spring(user_id: str, job_id: str, schedules: List[dict], token: str):
+async def _post_to_spring(user_id: str, job_id: str, schedules: List[dict], token: str, appcheck_token: str = ""):
     now = datetime.now(timezone.utc)
     month = now.month
     year = now.year
@@ -93,7 +93,7 @@ async def _post_to_spring(user_id: str, job_id: str, schedules: List[dict], toke
         for item in schedules
     ]
 
-    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json", "X-Firebase-AppCheck": appcheck_token}
     async with httpx.AsyncClient(timeout=10.0) as client:
         await client.post(SPRING_TIMETABLE_URL, json=payload, headers=headers)
 
@@ -101,7 +101,7 @@ async def _post_to_spring(user_id: str, job_id: str, schedules: List[dict], toke
 async def _queue_worker():
     loop = asyncio.get_running_loop()
     while True:
-        job_id, user_id, img, token = await _job_queue.get()
+        job_id, user_id, img, token, appcheck_token = await _job_queue.get()
         job = _job_store.get(job_id)
         if job is None:
             _active_users.discard(user_id)
@@ -115,7 +115,7 @@ async def _queue_worker():
             job["status"] = JobStatus.DONE
             print(f"[Worker DONE] job_id={job_id}, user_id={user_id}, result_count={len(result) if result else 0}")
             if result:
-                await _post_to_spring(user_id, job_id, result, token)
+                await _post_to_spring(user_id, job_id, result, token, appcheck_token)
             else:
                 print(f"[Worker] OCR result is empty, skipping Spring POST")
         except Exception as exc:
@@ -524,6 +524,7 @@ async def upload_timetable(request: Request, file: UploadFile = File(...)):
             return JSONResponse(status_code=400, content={"error": "Invalid image format"})
 
         token = request.headers.get("Authorization", "").split(" ")[1]
+        appcheck_token = request.headers.get("X-Firebase-AppCheck", "")
         job_id = str(uuid.uuid4())
         _job_store[job_id] = {
             "status":     JobStatus.PENDING,
@@ -531,7 +532,7 @@ async def upload_timetable(request: Request, file: UploadFile = File(...)):
         }
 
         try:
-            await asyncio.wait_for(_job_queue.put((job_id, user_id, img, token)), timeout=10.0)
+            await asyncio.wait_for(_job_queue.put((job_id, user_id, img, token, appcheck_token)), timeout=10.0)
         except asyncio.TimeoutError:
             _job_store.pop(job_id, None)
             _active_users.discard(user_id)


### PR DESCRIPTION
## 🎯 배경

- 시간표 자동분석 시 Spring 서버에 요청을 보내지 못한 오류가 발생하였습니다. worker의 상태와 환경변수 확인이 필요했습니다.

## 🔍 주요 내용

- [x] worker 진행 상태에 대한 log 추가
- [x] 환경변수 변경 후 log 확인
- [x] AppCheck logic 추가
- [x] 테스트 진행



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- 변경 요약(1~3줄)  
큐 워커에 진행 상태 로그와 AppCheck 토큰 전파를 추가하고 환경 변수 처리를 조정해 Spring 서버 요청 실패 원인 진단을 돕습니다. 관련 로직 수정 및 테스트를 수행했습니다.

- 주요 변경점
- _post_to_spring에 appcheck_token 파라미터 추가하고 요청 헤더에 X-Firebase-AppCheck 포함
- 큐에 appcheck_token을 함께 넣도록 upload_timetable/queue 삽입 로직 변경
- 워커에서 작업 완료, OCR 결과 없음, 예외 발생 시 상세 로그 추가(진행 상태/오류/결과 크기)
- 환경 변수 처리 변경 및 로그로 변경 사항 검증
- AppCheck 검증 흐름 추가 및 POST 스킵/성공 시 상태 마킹(DONE/ERROR) 유지
- 간단한 테스트 수행으로 동작 확인

- 주의/리스크
- 민감한 토큰(AppCheck 등)이 로그에 노출되지 않도록 주의 필요
- print 기반 로깅은 프로덕션에 적합하지 않으므로 로깅 모듈 도입 권장
- API 서명 변경(_post_to_spring)으로 호출부 호환성 확인 필요

- 다음 액션
- 민감 값 마스킹 및 logging 모듈로 리팩토링하여 로그 레벨/출력 제어 적용
- 변경된 서명과 AppCheck 전파가 다른 호출부에 미치는 영향 검토 및 수정
- 로그 분석으로 Spring 서버 요청 실패 원인 확정 및 대응 계획 수행
<!-- end of auto-generated comment: release notes by coderabbit.ai -->