### PR TITLE
fix: rule_book LMM empty answer and BM25 search quality improvement

### DIFF
--- a/LLM/rule_book/graph.py
+++ b/LLM/rule_book/graph.py
@@ -50,15 +50,17 @@ async def generate(state: RuleState) -> RuleState:
 
     context_parts = []
     for c in chunks:
-        context_parts.append(f"[출처: {c['source']} {c['article']}]\n{c['text']}")
+        text = c['text'][:300]
+        context_parts.append(f"[출처: {c['source']} {c['article']}]\n{text}")
     context = "\n\n".join(context_parts)
 
     system_prompt = (
         "당신은 동양미래대학교 규정집 전문 안내 챗봇입니다.\n"
-        "아래 <규정집 내용>만을 근거로 질문에 답하세요.\n"
+        "반드시 아래 <규정집 내용> 안의 텍스트만을 근거로 질문에 답하세요.\n"
+        "<규정집 내용> 외의 정보는 절대 사용하지 마세요.\n"
         "답변은 간결하고 명확하게, 관련 조문 번호와 출처를 함께 안내하세요.\n"
-        "규정집에 없는 내용은 '해당 규정을 찾을 수 없습니다'라고 답하세요.\n"
-        "임의로 정보를 만들지 마세요."
+        "<규정집 내용>에 질문과 관련된 내용이 없으면 '해당 규정을 찾을 수 없습니다'라고만 답하세요.\n"
+        "추측하거나 임의로 정보를 만들지 마세요."
     )
     user_prompt = f"질문: {state['query']}\n\n<규정집 내용>\n{context}\n</규정집 내용>"
 
@@ -70,10 +72,14 @@ async def generate(state: RuleState) -> RuleState:
                 {"role": "user",   "content": user_prompt},
             ],
             temperature=0.2,
-            max_tokens=512,
+            max_tokens=1024,
         )
-        answer = (resp.choices[0].message.content or "").strip()
+        choice = resp.choices[0]
+        finish_reason = choice.finish_reason
+        answer = (choice.message.content or "").strip()
+        logger.info("LLM finish_reason=%s, answer_len=%d", finish_reason, len(answer))
         if not answer:
+            logger.warning("LLM 빈 응답 반환 finish_reason=%s", finish_reason)
             answer = "답변을 생성하지 못했습니다. 다시 시도해 주세요."
         return {**state, "answer": answer}
     except Exception as e:

--- a/LLM/rule_book/graph.py
+++ b/LLM/rule_book/graph.py
@@ -46,7 +46,7 @@ async def generate(state: RuleState) -> RuleState:
 
     chunks = state.get("chunks", [])
     if not chunks:
-        return {**state, "answer": "관련 규정을 찾지 못했습니다. 더 구체적인 키워드로 질문해 주세요."}
+        return {**state, "answer": "해당 규정을 찾을 수 없습니다."}
 
     context_parts = []
     for c in chunks:

--- a/LLM/rule_book/index.py
+++ b/LLM/rule_book/index.py
@@ -40,7 +40,7 @@ def _chunk_pdf(path: Path) -> List[Dict]:
                 chunks.append({
                     "source": source,
                     "article": article_id,
-                    "text": article_id + " " + content,
+                    "text": source + " " + source + " " + article_id + " " + article_id + " " + content,
                 })
             i += 2
         header = parts[0].strip()

--- a/LLM/rule_book/index.py
+++ b/LLM/rule_book/index.py
@@ -40,7 +40,8 @@ def _chunk_pdf(path: Path) -> List[Dict]:
                 chunks.append({
                     "source": source,
                     "article": article_id,
-                    "text": source + " " + source + " " + article_id + " " + article_id + " " + content,
+                    "text": article_id + " " + content,
+                    "index_text": source + " " + source + " " + article_id + " " + article_id + " " + content,
                 })
             i += 2
         header = parts[0].strip()
@@ -86,7 +87,7 @@ class RuleBookIndex:
             raise ValueError("규정집 청크가 0개 — PDF 파싱 실패")
 
         self.chunks = all_chunks
-        tokenized = [_tokenize(c["text"]) for c in all_chunks]
+        tokenized = [_tokenize(c.get("index_text", c["text"])) for c in all_chunks]
         self.bm25 = BM25Okapi(tokenized)
         self._built = True
         print(f"[RuleBook] 인덱스 빌드 완료: {len(self.chunks)}개 청크")


### PR DESCRIPTION
## 관련 이슈

Open #85 

## 🎯 배경

- 챗봇 규정집 내용 질문 시 타임아웃 현상을 해결하기 위한 작업

## 🔍 주요 내용

- LLM reasoning max_token값 증가
- BM25 source article id 가중치 부여
- run_in_executor 비동기 처리 도입
- 에러 메시지 고정 문자열 변경, 서버 로그 기록

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 변경 요약
규정집 관련 챗봇의 타임아웃 문제를 해결하고 BM25 기반 검색 품질을 개선했습니다. LLM 토큰 한도를 늘리고 프롬프트 컨텍스트와 검색 색인을 조정했습니다.

## 주요 변경점
- 규정집 컨텍스트로 포함하는 각 청크의 텍스트를 300자만 사용하도록 제한
- LLM 추론용 max_tokens를 512→1024로 증가
- 시스템 프롬프트 강화: 제공된 규정집 내용만 사용하고 추측 금지 명시
- 규정 미검출 시 응답을 '해당 규정을 찾을 수 없습니다'로 통일
- PDF 청크에 index_text 필드 추가(소스·article_id 반복 포함)하여 BM25 색인에 가중치 반영
- 모델 응답의 finish_reason과 길이 로깅, 빈 응답 발생 시 경고 로그 기록
- run_in_executor 적용으로 비동기 처리 개선

## 주의/리스크
- 300자 제한으로 긴 규정의 일부 문맥 손실 가능
- BM25 가중치 변경으로 검색 순위가 예상과 달라질 수 있음(모니터링 필요)
- max_tokens 증가로 API 비용 상승 가능

## 다음 액션
- 프로덕션 배포 후 타임아웃 및 빈 응답 발생 여부 모니터링
- 검색 결과 품질을 실제 쿼리/사용자 피드백으로 검증
- 필요 시 컨텍스트 자르기 전략이나 색인 가중치 세부 조정 시행
<!-- end of auto-generated comment: release notes by coderabbit.ai -->