### PR TITLE
feat: add chatbot response logging to server database

### DIFF
--- a/LLM/OSS/Open_AI_OSS.py
+++ b/LLM/OSS/Open_AI_OSS.py
@@ -1,5 +1,6 @@
 import os, sys, re, asyncio, hashlib, time
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import List, Dict, Optional
 from jose import JWTError, jwt
@@ -12,6 +13,7 @@ from jose.exceptions import ExpiredSignatureError
 import datetime as dt
 from cachetools import TTLCache
 import psycopg2
+from psycopg2 import pool as pg_pool
 from sshtunnel import SSHTunnelForwarder
 
 from LLM.sub_model.query_index import build_answer
@@ -31,35 +33,45 @@ _cache_lock = threading.Lock()
 _CACHE_SKIP = frozenset({"oss", "greet", "whoami", "relation", "guard"})
 _RELATIVE_DATE_KEYWORDS = frozenset({"오늘", "내일", "이번주", "다음주", "이번달", "다음달"})
 
+_ssh_tunnel: Optional[SSHTunnelForwarder] = None
+_db_pool: Optional[pg_pool.ThreadedConnectionPool] = None
+_log_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="chatbot_log")
+
+def init_db_pool() -> None:
+    global _ssh_tunnel, _db_pool
+    ssh_host = os.getenv("SSH_HOST")
+    db_kwargs = dict(
+        dbname=os.getenv("DB_NAME"),
+        user=os.getenv("DB_USER"),
+        password=os.getenv("DB_PASSWORD"),
+        connect_timeout=3,
+        options="-c statement_timeout=5000",
+    )
+    if ssh_host:
+        _ssh_tunnel = SSHTunnelForwarder(
+            (ssh_host, 22),
+            ssh_username=os.getenv("SSH_USER"),
+            ssh_pkey=os.getenv("SSH_KEY_PATH"),
+            remote_bind_address=("localhost", 5433),
+        )
+        _ssh_tunnel.start()
+        db_kwargs.update(host="localhost", port=_ssh_tunnel.local_bind_port)
+    else:
+        db_kwargs["host"] = "localhost"
+    _db_pool = pg_pool.ThreadedConnectionPool(minconn=1, maxconn=5, **db_kwargs)
+
+def shutdown_db_pool() -> None:
+    if _db_pool:
+        _db_pool.closeall()
+    if _ssh_tunnel:
+        _ssh_tunnel.stop()
+
 def _log_chatbot(query: str, mode: str, response: str, url: Optional[str], cache_hit: bool, latency_ms: int):
-    tunnel = None
+    if _db_pool is None:
+        return
     conn = None
     try:
-        ssh_host = os.getenv("SSH_HOST")
-        if ssh_host:
-            tunnel = SSHTunnelForwarder(
-                (ssh_host, 22),
-                ssh_username=os.getenv("SSH_USER"),
-                ssh_pkey=os.getenv("SSH_KEY_PATH"),
-                remote_bind_address=("localhost", 5433),
-            )
-            tunnel.start()
-            conn = psycopg2.connect(
-                host="localhost",
-                port=tunnel.local_bind_port,
-                dbname=os.getenv("DB_NAME"),
-                user=os.getenv("DB_USER"),
-                password=os.getenv("DB_PASSWORD"),
-                connect_timeout=3,
-            )
-        else:
-            conn = psycopg2.connect(
-                host="localhost",
-                dbname=os.getenv("DB_NAME"),
-                user=os.getenv("DB_USER"),
-                password=os.getenv("DB_PASSWORD"),
-                connect_timeout=3,
-            )
+        conn = _db_pool.getconn()
         with conn:
             with conn.cursor() as cur:
                 cur.execute(
@@ -72,10 +84,8 @@ def _log_chatbot(query: str, mode: str, response: str, url: Optional[str], cache
     except Exception as e:
         print(f"[chatbot_log ERROR] {e}")
     finally:
-        if conn:
-            conn.close()
-        if tunnel:
-            tunnel.stop()
+        if conn and _db_pool:
+            _db_pool.putconn(conn)
 
 SECRET_KEY = os.getenv("SECRET_KEY")
 ALGORITHM = os.getenv("ALGORITHM")
@@ -901,11 +911,7 @@ async def chat(req: ChatReq, username: str = Depends(verify_jwt_token)):
         if _cached is not None:
             _latency = int((time.monotonic() - _start) * 1000)
             _r = dict(_cached)
-            threading.Thread(
-                target=_log_chatbot,
-                args=(user_text, mode, _r.get("text", ""), _r.get("url"), True, _latency),
-                daemon=True,
-            ).start()
+            _log_executor.submit(_log_chatbot, user_text, mode, _r.get("text", ""), _r.get("url"), True, _latency)
             return _r
 
     def _cache_and_return(resp: dict) -> dict:
@@ -914,11 +920,7 @@ async def chat(req: ChatReq, username: str = Depends(verify_jwt_token)):
             with _cache_lock:
                 _c[_cache_key] = resp
         _latency = int((time.monotonic() - _start) * 1000)
-        threading.Thread(
-            target=_log_chatbot,
-            args=(user_text, mode, resp.get("text", ""), resp.get("url"), False, _latency),
-            daemon=True,
-        ).start()
+        _log_executor.submit(_log_chatbot, user_text, mode, resp.get("text", ""), resp.get("url"), False, _latency)
         return resp
 
     if mode == "rule_book":
@@ -991,7 +993,7 @@ async def chat(req: ChatReq, username: str = Depends(verify_jwt_token)):
                 if sched_only:
                     _r = {"engine":"fast", "text": render_chatty_schedule(sched_only, user_text)}
                     _latency = int((time.monotonic() - _start) * 1000)
-                    threading.Thread(target=_log_chatbot, args=(user_text, "fast", _r["text"], None, False, _latency), daemon=True).start()
+                    _log_executor.submit(_log_chatbot, user_text, "fast", _r["text"], None, False, _latency)
                     return _r
 
             if len(user_text) <= 2 or GREETING_RE.search(user_text):
@@ -1001,7 +1003,7 @@ async def chat(req: ChatReq, username: str = Depends(verify_jwt_token)):
                 if looks_like_schedule(user_text) and sub:
                     _r = {"engine":"fast", "text": render_chatty_schedule(sub, user_text)}
                     _latency = int((time.monotonic() - _start) * 1000)
-                    threading.Thread(target=_log_chatbot, args=(user_text, "fast", _r["text"], None, False, _latency), daemon=True).start()
+                    _log_executor.submit(_log_chatbot, user_text, "fast", _r["text"], None, False, _latency)
                     return _r
                 if sub:
                     if looks_like_topic(user_text):
@@ -1012,7 +1014,7 @@ async def chat(req: ChatReq, username: str = Depends(verify_jwt_token)):
                 else:
                     out = "잘 이해하지 못했어요. 다시 질문해주세요."
         _latency = int((time.monotonic() - _start) * 1000)
-        threading.Thread(target=_log_chatbot, args=(user_text, "oss", out, None, False, _latency), daemon=True).start()
+        _log_executor.submit(_log_chatbot, user_text, "oss", out, None, False, _latency)
         return {"engine":"oss", "text": out}
 
     sub = call_submodel(user_text)
@@ -1027,7 +1029,7 @@ async def chat(req: ChatReq, username: str = Depends(verify_jwt_token)):
         text, _ = one_sentence_topic(user_text, sub)
         fused = text if looks_like_topic(user_text) else "좋아요, 무엇을 이야기해 볼까요?"
     _latency = int((time.monotonic() - _start) * 1000)
-    threading.Thread(target=_log_chatbot, args=(user_text, mode, fused, None, False, _latency), daemon=True).start()
+    _log_executor.submit(_log_chatbot, user_text, mode, fused, None, False, _latency)
     return {"engine": f"{mode}", "text": fused}
 
 

--- a/LLM/OSS/Open_AI_OSS.py
+++ b/LLM/OSS/Open_AI_OSS.py
@@ -1,4 +1,4 @@
-import os, sys, re, asyncio, hashlib
+import os, sys, re, asyncio, hashlib, time
 import threading
 from pathlib import Path
 from typing import List, Dict, Optional
@@ -11,6 +11,8 @@ import base64
 from jose.exceptions import ExpiredSignatureError
 import datetime as dt
 from cachetools import TTLCache
+import psycopg2
+from sshtunnel import SSHTunnelForwarder
 
 from LLM.sub_model.query_index import build_answer
 from LLM.sub_model.schedule_index import schedule_search
@@ -23,10 +25,57 @@ load_dotenv()
 _CACHE_RULE_BOOK: TTLCache = TTLCache(maxsize=200, ttl=86400)
 _CACHE_GENERAL:   TTLCache = TTLCache(maxsize=500, ttl=3600)
 _cache_lock = threading.Lock()
+
 # oss 모드는 대화 히스토리 의존 → 캐시 제외
 # greet/whoami/relation 은 고정 문자열 → 캐시 불필요
 _CACHE_SKIP = frozenset({"oss", "greet", "whoami", "relation", "guard"})
 _RELATIVE_DATE_KEYWORDS = frozenset({"오늘", "내일", "이번주", "다음주", "이번달", "다음달"})
+
+def _log_chatbot(query: str, mode: str, response: str, url: Optional[str], cache_hit: bool, latency_ms: int):
+    tunnel = None
+    conn = None
+    try:
+        ssh_host = os.getenv("SSH_HOST")
+        if ssh_host:
+            tunnel = SSHTunnelForwarder(
+                (ssh_host, 22),
+                ssh_username=os.getenv("SSH_USER"),
+                ssh_pkey=os.getenv("SSH_KEY_PATH"),
+                remote_bind_address=("localhost", 5433),
+            )
+            tunnel.start()
+            conn = psycopg2.connect(
+                host="localhost",
+                port=tunnel.local_bind_port,
+                dbname=os.getenv("DB_NAME"),
+                user=os.getenv("DB_USER"),
+                password=os.getenv("DB_PASSWORD"),
+                connect_timeout=3,
+            )
+        else:
+            conn = psycopg2.connect(
+                host="localhost",
+                dbname=os.getenv("DB_NAME"),
+                user=os.getenv("DB_USER"),
+                password=os.getenv("DB_PASSWORD"),
+                connect_timeout=3,
+            )
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO chatbot_logs (query, mode, response, url, cache_hit, latency_ms)
+                    VALUES (%s, %s, %s, %s, %s, %s)
+                    """,
+                    (query, mode, response, url, cache_hit, latency_ms),
+                )
+    except Exception as e:
+        print(f"[chatbot_log ERROR] {e}")
+    finally:
+        if conn:
+            conn.close()
+        if tunnel:
+            tunnel.stop()
 
 SECRET_KEY = os.getenv("SECRET_KEY")
 ALGORITHM = os.getenv("ALGORITHM")
@@ -826,6 +875,7 @@ def ensure_messages(req: ChatReq, user_text: str) -> List[Dict[str, str]]:
 
 @oss_router.post("/chatbot")
 async def chat(req: ChatReq, username: str = Depends(verify_jwt_token)):
+    _start = time.monotonic()
     user_text = extract_user_text(req)
     messages_for_oss = ensure_messages(req, user_text)
 
@@ -849,13 +899,26 @@ async def chat(req: ChatReq, username: str = Depends(verify_jwt_token)):
         with _cache_lock:
             _cached = _cache.get(_cache_key)
         if _cached is not None:
-            return dict(_cached)
+            _latency = int((time.monotonic() - _start) * 1000)
+            _r = dict(_cached)
+            threading.Thread(
+                target=_log_chatbot,
+                args=(user_text, mode, _r.get("text", ""), _r.get("url"), True, _latency),
+                daemon=True,
+            ).start()
+            return _r
 
     def _cache_and_return(resp: dict) -> dict:
         if mode not in _CACHE_SKIP:
             _c = _CACHE_RULE_BOOK if mode == "rule_book" else _CACHE_GENERAL
             with _cache_lock:
                 _c[_cache_key] = resp
+        _latency = int((time.monotonic() - _start) * 1000)
+        threading.Thread(
+            target=_log_chatbot,
+            args=(user_text, mode, resp.get("text", ""), resp.get("url"), False, _latency),
+            daemon=True,
+        ).start()
         return resp
 
     if mode == "rule_book":
@@ -926,14 +989,20 @@ async def chat(req: ChatReq, username: str = Depends(verify_jwt_token)):
             if looks_like_schedule(user_text):
                 sched_only = schedule_search(user_text, top_k=8)
                 if sched_only:
-                    return {"engine":"fast", "text": render_chatty_schedule(sched_only, user_text)}
+                    _r = {"engine":"fast", "text": render_chatty_schedule(sched_only, user_text)}
+                    _latency = int((time.monotonic() - _start) * 1000)
+                    threading.Thread(target=_log_chatbot, args=(user_text, "fast", _r["text"], None, False, _latency), daemon=True).start()
+                    return _r
 
             if len(user_text) <= 2 or GREETING_RE.search(user_text):
                 out = "안녕하세요, 무엇을 도와드릴까요?"
             else:
                 sub = call_submodel(user_text)
                 if looks_like_schedule(user_text) and sub:
-                    return {"engine":"fast", "text": render_chatty_schedule(sub, user_text)}
+                    _r = {"engine":"fast", "text": render_chatty_schedule(sub, user_text)}
+                    _latency = int((time.monotonic() - _start) * 1000)
+                    threading.Thread(target=_log_chatbot, args=(user_text, "fast", _r["text"], None, False, _latency), daemon=True).start()
+                    return _r
                 if sub:
                     if looks_like_topic(user_text):
                         text, _ = one_sentence_topic(user_text, sub)
@@ -942,6 +1011,8 @@ async def chat(req: ChatReq, username: str = Depends(verify_jwt_token)):
                     out = text
                 else:
                     out = "잘 이해하지 못했어요. 다시 질문해주세요."
+        _latency = int((time.monotonic() - _start) * 1000)
+        threading.Thread(target=_log_chatbot, args=(user_text, "oss", out, None, False, _latency), daemon=True).start()
         return {"engine":"oss", "text": out}
 
     sub = call_submodel(user_text)
@@ -955,6 +1026,8 @@ async def chat(req: ChatReq, username: str = Depends(verify_jwt_token)):
     if not fused:
         text, _ = one_sentence_topic(user_text, sub)
         fused = text if looks_like_topic(user_text) else "좋아요, 무엇을 이야기해 볼까요?"
+    _latency = int((time.monotonic() - _start) * 1000)
+    threading.Thread(target=_log_chatbot, args=(user_text, mode, fused, None, False, _latency), daemon=True).start()
     return {"engine": f"{mode}", "text": fused}
 
 

--- a/app_oss_main.py
+++ b/app_oss_main.py
@@ -1,14 +1,16 @@
 from contextlib import asynccontextmanager
 import asyncio
 from fastapi import FastAPI
-from LLM.OSS.Open_AI_OSS import router as Open_AI_OSS
+from LLM.OSS.Open_AI_OSS import router as Open_AI_OSS, init_db_pool, shutdown_db_pool
 from LLM.rule_book.index import build_index
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await asyncio.get_event_loop().run_in_executor(None, build_index)
+    await asyncio.get_event_loop().run_in_executor(None, init_db_pool)
     yield
+    shutdown_db_pool()
 
 
 app = FastAPI(lifespan=lifespan)


### PR DESCRIPTION
## 관련 이슈

Closes #89 

## 🎯 배경

- 챗봇 응답 품질 개선을 위한 모니터링이 필요했습니다. 데이터를 데이터베이스에 저장하여 챗봇 응답 품질을 개선에 사용합니다.

## 🔍 주요 내용

- [x] 챗봇 데이터 테이블 생성 `chatbot_logs`
- [x] 로깅 방식 구현 `threading` 비동기 처리
- [x] cache_key 개선

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 요약
챗봇의 모든 응답을 PostgreSQL 데이터베이스에 자동으로 기록하여 사용자 질의, 응답 모드, 응답 내용, 캐시 여부, 응답 시간 등을 추적할 수 있도록 개선했습니다.

## 주요 변경점
- `_log_chatbot()` 헬퍼 함수 추가: SSH 터널을 통한 원격 DB 접속 지원 및 chatbot_logs 테이블에 INSERT
- `/chatbot` 엔드포인트에 `time.monotonic()`을 이용한 응답 레이턴시 측정 로직 추가
- 캐시 히트 시점에 응답 내용과 함께 로깅 데몬 스레드 생성
- 캐시 미스 시 `_cache_and_return()` 헬퍼 함수 내에서 로깅 처리
- OSS 모드의 여러 반환 지점(스케줄 검색, 최종 응답 등)에 로깅 추가
- 신규 의존성: `psycopg2`, `sshtunnel` 임포트

## 주의/리스크
- 데몬 스레드로 실행되므로 DB 연결 실패 시 무시됨 (에러는 콘솔에만 출력)
- 환경변수(`DB_NAME`, `DB_USER`, `DB_PASSWORD`, `SSH_HOST` 등)가 올바르게 설정되지 않으면 로깅이 작동하지 않음
- 코드 여러 지점에서 동일한 로깅 로직이 반복되어 유지보수 복잡도 증가

## 다음 액션
- `chatbot_logs` 테이블 스키마 생성 및 마이그레이션 실행 필요
- 환경변수 설정 검증 (특히 DB 접속 정보 및 SSH 관련 설정)
- 로깅 기능의 동작 확인 테스트 (DB에 데이터가 정상 저장되는지 검증)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->