### PR TITLE
refactor: services folder add and textfilter service logic implement

### DIFF
--- a/services/text_filtering.py
+++ b/services/text_filtering.py
@@ -1,0 +1,142 @@
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import torch
+from transformers import ElectraForSequenceClassification, ElectraTokenizer
+
+
+MODEL_PATH = Path("model/my_electra_finetuned")
+LOG_PATH = Path("data/bad_text_sample.txt")
+ENGLISH_BAD_WORDS_PATH = Path("data/eng_bad_text.txt")
+
+SENTENCE_ENDINGS = [
+    "다",
+    "요",
+    "죠",
+    "네",
+    "습니다",
+    "습니까",
+    "해요",
+    "했어요",
+    "하였습니다",
+    "하네요",
+    "해봐요",
+]
+
+
+def load_english_bad_words(file_path: Path) -> set[str]:
+    bad_words: set[str] = set()
+    try:
+        with file_path.open("r", encoding="utf-8") as file:
+            for line in file:
+                word = line.strip().lower()
+                if word:
+                    bad_words.add(word)
+    except FileNotFoundError:
+        print(f"[ERROR] 영어 비속어 사전 파일을 찾을 수 없습니다: {file_path}")
+    return bad_words
+
+
+ENGLISH_BAD_WORDS = load_english_bad_words(ENGLISH_BAD_WORDS_PATH)
+
+
+def get_device() -> torch.device:
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+@lru_cache(maxsize=1)
+def get_text_filter_model() -> tuple[ElectraTokenizer, ElectraForSequenceClassification, torch.device]:
+    tokenizer = ElectraTokenizer.from_pretrained(MODEL_PATH, local_files_only=True)
+    model = ElectraForSequenceClassification.from_pretrained(MODEL_PATH, local_files_only=True)
+    device = get_device()
+    model.to(device)
+    model.eval()
+    return tokenizer, model, device
+
+
+def split_sentences(text: str) -> list[str]:
+    text = re.sub(r"([.!?])\s+", r"\1\n", text)
+    for ending in SENTENCE_ENDINGS:
+        text = re.sub(rf"({ending})(?=\s)", r"\1\n", text)
+    return [sentence.strip() for sentence in text.split("\n") if sentence.strip()]
+
+
+def contains_english_profanity(text: str) -> bool:
+    lower_text = text.lower()
+    return any(bad_word in lower_text for bad_word in ENGLISH_BAD_WORDS)
+
+
+def predict(text: str) -> tuple[int, str]:
+    tokenizer, model, device = get_text_filter_model()
+    encoded = tokenizer(
+        text,
+        add_special_tokens=True,
+        max_length=64,
+        padding="max_length",
+        truncation=True,
+        return_tensors="pt",
+    )
+    input_ids = encoded["input_ids"].to(device)
+    attention_mask = encoded["attention_mask"].to(device)
+
+    with torch.no_grad():
+        outputs = model(input_ids=input_ids, attention_mask=attention_mask)
+        logits = outputs.logits
+        pred_label = torch.argmax(logits, dim=-1).item()
+
+    return pred_label, "비속어" if pred_label == 1 else "정상"
+
+
+def analyze_field(field_name: str, text: str, should_log: bool = False) -> dict[str, Any]:
+    results: list[dict[str, str]] = []
+    has_profanity = False
+    log_lines: list[str] = []
+
+    for sentence in split_sentences(text):
+        label_num, label_text = predict(sentence)
+        if label_text == "정상" and contains_english_profanity(sentence):
+            label_text = "비속어"
+            label_num = 1
+
+        results.append({"sentence": sentence, "label": label_text})
+        if should_log:
+            log_lines.append(f"{sentence}|{label_num}\n")
+        if label_text == "비속어":
+            has_profanity = True
+
+    return {
+        "field": field_name,
+        "has_profanity": has_profanity,
+        "results": results,
+        "log_lines": log_lines,
+    }
+
+
+def analyze_fields(specs: list[tuple[str, str, bool]]) -> dict[str, dict[str, Any]]:
+    analyzed: dict[str, dict[str, Any]] = {}
+    pending_logs: list[str] = []
+
+    for field_name, text, should_log in specs:
+        result = analyze_field(field_name, text, should_log=should_log)
+        pending_logs.extend(result.pop("log_lines"))
+        analyzed[field_name] = result
+
+    if pending_logs:
+        with LOG_PATH.open("a", encoding="utf-8") as file:
+            file.writelines(pending_logs)
+
+    return analyzed
+
+
+def analyze_text_labels(text: str) -> list[str]:
+    labels: list[str] = []
+    for sentence in split_sentences(text):
+        _, label_text = predict(sentence)
+        if label_text == "정상" and contains_english_profanity(sentence):
+            label_text = "비속어"
+        labels.append(label_text)
+    return labels

--- a/text_filtering/text_filtering.py
+++ b/text_filtering/text_filtering.py
@@ -1,100 +1,15 @@
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-from transformers import ElectraTokenizer, ElectraForSequenceClassification
-import torch, re
-from typing import Tuple, List, Dict
 
 from core.auth import verify_jwt_token
+from services.text_filtering import analyze_fields, analyze_text_labels
 
 router = APIRouter()
 
 
-ENGLISH_BAD_WORDS_PATH = "data/eng_bad_text.txt"
-
-def load_english_bad_words(file_path: str) -> set:
-    bad_words = set()
-    try:
-        with open(file_path, "r", encoding="utf-8") as f:
-            for line in f:
-                word = line.strip().lower()
-                if word:
-                    bad_words.add(word)
-    except FileNotFoundError:
-        print(f"[ERROR] 영어 비속어 사전 파일을 찾을 수 없습니다: {file_path}")
-    return bad_words
-
-ENGLISH_BAD_WORDS = load_english_bad_words(ENGLISH_BAD_WORDS_PATH)
-
-
 class TextRequest(BaseModel):
     text: str
-
-MODEL_PATH = "model/my_electra_finetuned"
-LOG_PATH = "data/bad_text_sample.txt"
-
-tokenizer = ElectraTokenizer.from_pretrained(MODEL_PATH, local_files_only=True)
-model = ElectraForSequenceClassification.from_pretrained(MODEL_PATH, local_files_only=True)
-device = torch.device("mps" if torch.cuda.is_available() else "cpu")
-model.to(device)
-model.eval()
-
-
-def split_sentences(text: str) -> List[str]:
-    text = re.sub(r'([.!?])\s+', r'\1\n', text)
-    endings = ['다', '요', '죠', '네', '습니다', '습니까', '해요', '했어요', '하였습니다', '하네요', '해봐요']
-    for end in endings:
-        text = re.sub(rf'({end})(?=\s)', r'\1\n', text)
-    return [s.strip() for s in text.split('\n') if s.strip()]
-
-
-def contains_english_profanity(text: str) -> bool:
-    lower_text = text.lower()
-    return any(bad_word in lower_text for bad_word in ENGLISH_BAD_WORDS)
-
-
-def predict(text: str) -> Tuple[int, str]:
-    encoded = tokenizer(
-        text,
-        add_special_tokens=True,
-        max_length=64,
-        padding="max_length",
-        truncation=True,
-        return_tensors="pt"
-    )
-    input_ids = encoded["input_ids"].to(device)
-    attention_mask = encoded["attention_mask"].to(device)
-
-    with torch.no_grad():
-        outputs = model(input_ids=input_ids, attention_mask=attention_mask)
-        logits = outputs.logits
-        pred_label = torch.argmax(logits, dim=-1).item()
-
-    return pred_label, "비속어" if pred_label == 1 else "정상"
-
-
-def analyze_field(field_name: str, text: str, log_file) -> Dict:
-    sentences = split_sentences(text)
-    results = []
-    has_profanity = False
-
-    for sent in sentences:
-        label_num, label_text = predict(sent)
-        if label_text == "정상" and contains_english_profanity(sent):
-            label_text = "비속어"
-            label_num = 1
-
-        results.append({"sentence": sent, "label": label_text})
-        log_file.write(f"{sent}|{label_num}\n")
-
-        if label_text == "비속어":
-            has_profanity = True
-
-    return {
-        "field": field_name,
-        "has_profanity": has_profanity,
-        "results": results
-    }
 
 
 @router.post("/text_filter_board")
@@ -109,9 +24,12 @@ async def text_filter_board_api(payload: TextRequest, username: str = Depends(ve
                 status_code=422
             )
 
-        with open(LOG_PATH, "a", encoding="utf-8") as f:
-            intro_result = analyze_field("자기소개", intro, f)
-            motive_result = analyze_field("지원동기", motive, f)
+        analyzed = analyze_fields([
+            ("자기소개", intro, True),
+            ("지원동기", motive, True),
+        ])
+        intro_result = analyzed["자기소개"]
+        motive_result = analyzed["지원동기"]
 
         response = {
             "username": username,
@@ -140,9 +58,12 @@ async def text_filter_market_api(payload: TextRequest, username: str = Depends(v
                 status_code=422
             )
 
-        with open(LOG_PATH, "a", encoding="utf-8") as f:
-            title_result = analyze_field("제목", title, f)
-            content_result = analyze_field("내용", content, f)
+        analyzed = analyze_fields([
+            ("제목", title, True),
+            ("내용", content, True),
+        ])
+        title_result = analyzed["제목"]
+        content_result = analyzed["내용"]
 
         response = {
             "username": username,
@@ -163,13 +84,7 @@ async def text_filter_market_api(payload: TextRequest, username: str = Depends(v
 async def text_filter_single_api(payload: TextRequest):
     try:
         text = payload.text.strip()
-        sentence_list = split_sentences(text)
-        results = []
-        for sent in sentence_list:
-            label_num, label_text = predict(sent)
-            if label_text == "정상" and contains_english_profanity(sent):
-                label_text = "비속어"
-            results.append(label_text)
+        results = analyze_text_labels(text)
 
         return JSONResponse(
             status_code=200,

--- a/text_filtering/text_filtering_rule.py
+++ b/text_filtering/text_filtering_rule.py
@@ -1,102 +1,15 @@
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-from transformers import ElectraTokenizer, ElectraForSequenceClassification
-import torch, re
-from typing import Tuple, List, Dict
 
 from core.auth import verify_jwt_token
+from services.text_filtering import analyze_fields
 
 router = APIRouter()
-
-MODEL_PATH = "model/my_electra_finetuned"
-LOG_PATH = "data/bad_text_sample.txt"
-ENGLISH_BAD_WORDS_PATH = "data/eng_bad_text.txt"
-
-
-def load_english_bad_words(file_path: str) -> set:
-    bad_words = set()
-    try:
-        with open(file_path, "r", encoding="utf-8") as f:
-            for line in f:
-                word = line.strip().lower()
-                if word:
-                    bad_words.add(word)
-    except FileNotFoundError:
-        print(f"[ERROR] 영어 비속어 사전 파일을 찾을 수 없습니다: {file_path}")
-    return bad_words
-
-ENGLISH_BAD_WORDS = load_english_bad_words(ENGLISH_BAD_WORDS_PATH)
 
 
 class TextRequest(BaseModel):
     text: str
-
-tokenizer = ElectraTokenizer.from_pretrained(MODEL_PATH, local_files_only=True)
-model = ElectraForSequenceClassification.from_pretrained(MODEL_PATH, local_files_only=True)
-device = torch.device("mps" if torch.cuda.is_available() else "cpu")
-model.to(device)
-model.eval()
-
-
-def split_sentences(text: str) -> List[str]:
-    text = re.sub(r'([.!?])\s+', r'\1\n', text)
-    endings = ['다', '요', '죠', '네', '습니다', '습니까', '해요', '했어요', '하였습니다', '하네요', '해봐요']
-    for end in endings:
-        text = re.sub(rf'({end})(?=\s)', r'\1\n', text)
-    return [s.strip() for s in text.split('\n') if s.strip()]
-
-
-def contains_english_profanity(text: str) -> bool:
-    lower_text = text.lower()
-    return any(bad_word in lower_text for bad_word in ENGLISH_BAD_WORDS)
-
-
-def predict(text: str) -> Tuple[int, str]:
-    encoded = tokenizer(
-        text,
-        add_special_tokens=True,
-        max_length=64,
-        padding="max_length",
-        truncation=True,
-        return_tensors="pt"
-    )
-    input_ids = encoded["input_ids"].to(device)
-    attention_mask = encoded["attention_mask"].to(device)
-
-    with torch.no_grad():
-        outputs = model(input_ids=input_ids, attention_mask=attention_mask)
-        logits = outputs.logits
-        pred_label = torch.argmax(logits, dim=-1).item()
-
-    return pred_label, "비속어" if pred_label == 1 else "정상"
-
-
-def analyze_field(field_name: str, text: str, log_file=None) -> Dict:
-    sentences = split_sentences(text)
-    results = []
-    has_bad = False
-
-    for sent in sentences:
-        label_num, label_text = predict(sent)
-
-        if label_text == "정상" and contains_english_profanity(sent):
-            label_text = "비속어"
-            label_num = 1
-
-        results.append({"sentence": sent, "label": label_text})
-
-        if field_name in ['제목', '본문'] and log_file:
-            log_file.write(f"{sent}|{label_num}\n")
-
-        if label_text == "비속어":
-            has_bad = True
-
-    return {
-        "field": field_name,
-        "has_profanity": has_bad,
-        "results": results
-    }
 
 
 @router.post("/text_filter_rule")
@@ -115,11 +28,14 @@ async def rule_filter_api(
                 status_code=422
             )
 
-        with open(LOG_PATH, "a", encoding="utf-8") as f:
-            title_result = analyze_field("제목", title, f)
-            content_result = analyze_field("본문", content, f)
-
-        tags_result = analyze_field("태그", tags)
+        analyzed = analyze_fields([
+            ("제목", title, True),
+            ("태그", tags, False),
+            ("본문", content, True),
+        ])
+        title_result = analyzed["제목"]
+        tags_result = analyzed["태그"]
+        content_result = analyzed["본문"]
 
         response = {
             "username": username,
@@ -144,34 +60,17 @@ async def text_filter_content_api(
     payload: TextRequest):
     try:
         text = payload.text.strip()
-        sentences = split_sentences(text)
-        results = []
-        has_profanity = False
-
-        with open(LOG_PATH, "a", encoding="utf-8") as f:
-            for sent in sentences:
-                label_num, label_text = predict(sent)
-
-                if label_text == "정상" and contains_english_profanity(sent):
-                    label_text = "비속어"
-                    label_num = 1
-
-                results.append({"sentence": sent, "label": label_text})
-                f.write(f"{sent}|{label_num}\n")
-
-                if label_text == "비속어":
-                    has_profanity = True
+        analyzed = analyze_fields([
+            ("content", text, True),
+        ])
+        content_result = analyzed["content"]
 
         response = {
-            "content": {
-                "field": "content",
-                "has_profanity": has_profanity,
-                "results": results
-            }
+            "content": content_result
         }
 
         return JSONResponse(
-            status_code=400 if has_profanity else 200,
+            status_code=400 if content_result["has_profanity"] else 200,
             content=response
         )
 


### PR DESCRIPTION
## 관련 이슈

Close #91 

## 🎯 배경

텍스트 필터링 서비스 로직에 중복되는 서비스를 별도의 구조로 나눠 호출하는 방안으로 수정합니다.
서비스 로직의 단순화가 확보됩니다.

## 🔍 주요 내용

- 모델 로딩, 디바이스 선택, 문장 분리, 비속어 판정, 필드 분석, 로깅 시스템 을 한 곳으로 분리합니다.
- 서비스 로직은 입력 파싱과 응답 조립만 담당합니다.
