### PR TITLE
feat: add metadata first chatbot responses and optimize rule_book dir…

### DIFF
--- a/LLM/OSS/modes.py
+++ b/LLM/OSS/modes.py
@@ -19,7 +19,7 @@ RELATION_RE = re.compile(
     )
 
 UNIT_SUFFIX_RE = re.compile(r"(학부|학과|과|전공|대학|대학원|본부|센터|팀|처|단|부|원)$")
-CEREMONY_RE = re.compile(r"(졸업식|학위수여식)")
+CEREMONY_RE = re.compile(r"(졸업식|종업식|학위수여식)")
 GRAD_POLICY_RE = re.compile(r"(졸업학점|이수학점|졸업요건|전공최저|최저이수|학위수여(?!식)|졸업(?!식))")
 CONTACT_INTENT_RE = re.compile(r"(연락처|전화|전화번호|문의|상담|담당자)")
 GOVERNANCE_REMOVE_RE = re.compile(r"(없애|폐지|해체)\s*(시키|하는\s*법)?")
@@ -34,7 +34,7 @@ SCHEDULE_HINTS_BASE = (
     "학사일정", "학사 일정", "중간", "중간고사", "기말", "기말고사",
     "수강", "정정", "성적", "등록", "보강", "개강", "종강",
     "휴일", "공휴", "시험", "고사", "이번주", "다음주", "이번달", "다음달",
-    "졸업식", "학위수여식",
+    "졸업식", "종업식", "학위수여식",
 )
 RULE_BOOK_KWS = ("규정", "규정집", "학칙", "준칙", "회칙", "규약", "세칙", "강령", "운영규칙", "선발 규칙", "선발규칙")
 
@@ -73,7 +73,7 @@ def looks_like_schedule(text: str) -> bool:
         return True
     return "언제" in source and any(
         keyword in source
-        for keyword in ("중간", "기말", "시험", "고사", "수강", "등록", "성적", "개강", "종강", "졸업식", "학위수여식")
+        for keyword in ("중간", "기말", "시험", "고사", "수강", "등록", "성적", "개강", "종강", "졸업식", "종업식", "학위수여식")
     )
 
 

--- a/LLM/OSS/service.py
+++ b/LLM/OSS/service.py
@@ -32,7 +32,7 @@ from LLM.OSS.modes import (
 )
 from LLM.OSS.postprocess import run_postprocess
 from LLM.rule_book.graph import run_rule_book
-from LLM.sub_model.query_index import build_answer
+from LLM.sub_model.query_index import build_answer, confident_search_answer, metadata_direct_answer
 from LLM.sub_model.schedule_index import schedule_search
 
 
@@ -198,6 +198,7 @@ def call_oss(messages: list[dict[str, str]], **kwargs) -> str:
             messages=messages,
             temperature=kwargs.get("temperature", 0.3),
             max_tokens=kwargs.get("max_tokens", 64),
+            timeout=kwargs.get("timeout", 45),
         )
         return (response.choices[0].message.content or "").strip()
     except Exception:
@@ -296,6 +297,13 @@ async def chat_with_oss(req: ChatReq) -> dict:
         }
 
     if mode == "fast":
+        direct = metadata_direct_answer(user_text)
+        if direct:
+            response = {"engine": "fast", "text": direct["answer"]}
+            if direct.get("url"):
+                response["url"] = direct["url"]
+            return cache_and_return(response)
+
         schedule_only = schedule_search(user_text, top_k=8)
         if schedule_only:
             return cache_and_return({"engine": "fast", "text": render_chatty_schedule(schedule_only, user_text)})
@@ -312,6 +320,13 @@ async def chat_with_oss(req: ChatReq) -> dict:
         return cache_and_return(response)
 
     if mode == "policy":
+        direct = metadata_direct_answer(user_text)
+        if direct:
+            response = {"engine": "policy", "text": direct["answer"]}
+            if direct.get("url"):
+                response["url"] = direct["url"]
+            return cache_and_return(response)
+
         sub_answer = call_submodel(user_text)
         text, url = run_postprocess("policy", user_text, sub_answer)
         response = {"engine": "policy", "text": text}
@@ -328,6 +343,13 @@ async def chat_with_oss(req: ChatReq) -> dict:
         return cache_and_return(response)
 
     if mode == "grad":
+        direct = metadata_direct_answer(user_text)
+        if direct:
+            response = {"engine": "grad", "text": direct["answer"]}
+            if direct.get("url"):
+                response["url"] = direct["url"]
+            return cache_and_return(response)
+
         sub_answer = call_submodel(user_text)
         text, url = run_postprocess("grad", user_text, sub_answer)
         response = {"engine": "grad", "text": text}
@@ -344,6 +366,20 @@ async def chat_with_oss(req: ChatReq) -> dict:
         return cache_and_return(response)
 
     if mode == "oss":
+        direct = metadata_direct_answer(user_text)
+        if direct:
+            response = {"engine": "fast", "text": direct["answer"]}
+            if direct.get("url"):
+                response["url"] = direct["url"]
+            return cache_and_return(response)
+
+        confident = confident_search_answer(user_text, top_k=2)
+        if confident:
+            response = {"engine": "fast", "text": confident["answer"]}
+            if confident.get("url"):
+                response["url"] = confident["url"]
+            return cache_and_return(response)
+
         output = call_oss(messages_for_oss)
         if not any(keyword in user_text for keyword in ("연락처", "전화", "번호", "문의")) and not any(keyword in user_text for keyword in COUNCIL_KWS):
             output = scrub_non_contact(output)
@@ -379,6 +415,20 @@ async def chat_with_oss(req: ChatReq) -> dict:
         _log_executor.submit(_log_chatbot, user_text, "oss", output, None, False, latency)
         return {"engine": "oss", "text": output}
 
+    direct = metadata_direct_answer(user_text)
+    if direct:
+        response = {"engine": "fast", "text": direct["answer"]}
+        if direct.get("url"):
+            response["url"] = direct["url"]
+        return cache_and_return(response)
+
+    confident = confident_search_answer(user_text, top_k=2)
+    if confident:
+        response = {"engine": "fast", "text": confident["answer"]}
+        if confident.get("url"):
+            response["url"] = confident["url"]
+        return cache_and_return(response)
+
     sub_answer = call_submodel(user_text)
     fused = call_oss(
         [
@@ -388,8 +438,9 @@ async def chat_with_oss(req: ChatReq) -> dict:
             },
             {"role": "user", "content": user_text + "\n\n<context>\n" + (sub_answer or "") + "\n</context>"},
         ],
-        max_tokens=64,
+        max_tokens=96,
         temperature=0.2,
+        timeout=45,
     )
     if not fused:
         text, _ = run_postprocess("topic", user_text, sub_answer)

--- a/LLM/OSS/service.py
+++ b/LLM/OSS/service.py
@@ -1,8 +1,10 @@
 import datetime as dt
+import asyncio
 import hashlib
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from pathlib import Path
 from typing import Optional
 
@@ -47,6 +49,7 @@ _cache_lock = threading.Lock()
 _ssh_tunnel: Optional[SSHTunnelForwarder] = None
 _db_pool: Optional[pg_pool.ThreadedConnectionPool] = None
 _log_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="chatbot_log")
+_oss_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="chatbot_oss")
 
 _client: Optional[OpenAI] = None
 _client_lock = threading.Lock()
@@ -206,6 +209,11 @@ def call_oss(messages: list[dict[str, str]], **kwargs) -> str:
         return ""
 
 
+async def call_oss_async(messages: list[dict[str, str]], **kwargs) -> str:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_oss_executor, partial(call_oss, messages, **kwargs))
+
+
 def call_submodel(user_text: str) -> str:
     base = ""
     try:
@@ -250,6 +258,7 @@ async def chat_with_oss(req: ChatReq) -> dict:
     start = time.monotonic()
     user_text = extract_user_text(req)
     messages_for_oss = ensure_messages(req, user_text)
+    compact_user_text = "".join(user_text.split())
 
     if GOVERNANCE_REMOVE_RE.search(user_text) and GOVERNANCE_TARGET_RE.search(user_text):
         return {
@@ -258,6 +267,8 @@ async def chat_with_oss(req: ChatReq) -> dict:
         }
 
     mode = req.engine or decide_mode(user_text)
+    if mode == "oss" and len(compact_user_text) <= 2:
+        return {"engine": "greet", "text": "네, 무엇을 도와드릴까요?"}
     normalized = " ".join(user_text.strip().split())
     relative_date_scope = ""
     if looks_like_schedule(user_text) and any(keyword in user_text for keyword in RELATIVE_DATE_KEYWORDS):
@@ -297,6 +308,11 @@ async def chat_with_oss(req: ChatReq) -> dict:
         }
 
     if mode == "fast":
+        if any(keyword in user_text for keyword in ("종강", "졸업식", "종업식", "학위수여식")):
+            schedule_only = schedule_search(user_text, top_k=8)
+            if schedule_only:
+                return cache_and_return({"engine": "fast", "text": render_chatty_schedule(schedule_only, user_text)})
+
         direct = metadata_direct_answer(user_text)
         if direct:
             response = {"engine": "fast", "text": direct["answer"]}
@@ -380,7 +396,7 @@ async def chat_with_oss(req: ChatReq) -> dict:
                 response["url"] = confident["url"]
             return cache_and_return(response)
 
-        output = call_oss(messages_for_oss)
+        output = await call_oss_async(messages_for_oss)
         if not any(keyword in user_text for keyword in ("연락처", "전화", "번호", "문의")) and not any(keyword in user_text for keyword in COUNCIL_KWS):
             output = scrub_non_contact(output)
 
@@ -430,7 +446,7 @@ async def chat_with_oss(req: ChatReq) -> dict:
         return cache_and_return(response)
 
     sub_answer = call_submodel(user_text)
-    fused = call_oss(
+    fused = await call_oss_async(
         [
             {
                 "role": "system",

--- a/LLM/patterns.py
+++ b/LLM/patterns.py
@@ -62,7 +62,7 @@ DEPT_CONTACT_INTENT_PATTERN = (
 )
 
 SCHED_LINE_PATTERN = (
-    r"^\s*-\s*(?P<title>[^:]+):\s*(?P<s>\d{4}-\d{2}-\d{2})"
+    r"^\s*-\s*(?P<title>.+?):\s*(?P<s>\d{4}-\d{2}-\d{2})"
     r"(?:\s*~\s*(?P<e>\d{4}-\d{2}-\d{2}))?$"
 )
 LINE_PATTERN = r"^\s*-\s*(?P<label>[^:：]+)[:：]\s*(?P<body>.+)$"

--- a/LLM/rule_book/graph.py
+++ b/LLM/rule_book/graph.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import re
 import time
 import logging
 from typing import TypedDict, List, Dict, Optional
@@ -19,6 +20,12 @@ _async_client = AsyncOpenAI(
 OSS_MODEL = os.getenv("OSS_MODEL")
 
 TOP_K = int(os.getenv("RULE_BOOK_TOP_K", "5"))
+LLM_TOP_K = int(os.getenv("RULE_BOOK_LLM_TOP_K", "2"))
+LLM_MAX_TOKENS = int(os.getenv("RULE_BOOK_LLM_MAX_TOKENS", "192"))
+LLM_TIMEOUT_SECONDS = float(os.getenv("RULE_BOOK_LLM_TIMEOUT_SECONDS", "45"))
+DIRECT_RULE_TERMS_RE = re.compile(r"(임기|기간|자격|권한|의무|선출|선임|구성|정족수|징계|사퇴|해임|소집)")
+RULE_BOOK_NOISE_RE = re.compile(r"(규정집|규정|학칙|준칙|회칙|규약|세칙|강령|운영규칙|찾아줘|알려줘|에서)")
+ARTICLE_HEADING_RE = re.compile(r"^제\s*\d+\s*조(?:의\d+)?(?:\([^)]*\))?$")
 
 class RuleState(TypedDict):
     query: str
@@ -40,6 +47,86 @@ async def retrieve(state: RuleState) -> RuleState:
         return {**state, "chunks": [], "error": "규정집 검색 중 오류가 발생했습니다."}
 
 
+def _query_terms(query: str) -> list[str]:
+    cleaned = RULE_BOOK_NOISE_RE.sub(" ", query or "")
+    terms = [t for t in re.findall(r"[가-힣A-Za-z0-9]{2,}", cleaned) if len(t) >= 2]
+    return list(dict.fromkeys(terms))
+
+
+def _clean_text(text: str, max_chars: int = 360) -> str:
+    text = re.sub(r"\s+", " ", text or "").strip()
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars].rstrip() + "..."
+
+
+def _split_rule_sentences(text: str) -> list[str]:
+    lines = [line.strip() for line in (text or "").splitlines() if line.strip()]
+    candidates = []
+    for line in lines:
+        candidates.extend(part.strip() for part in re.split(r"(?<=[다요함음)])\s+", line) if part.strip())
+    if not candidates:
+        candidates = [part.strip() for part in re.split(r"(?<=[.!?])\s+", text or "") if part.strip()]
+    return candidates
+
+
+def _source_label(chunk: Dict) -> str:
+    source = (chunk.get("source") or "").strip()
+    article = (chunk.get("article") or "").strip()
+    return f"{source} {article}".strip()
+
+
+def _direct_answer_from_chunks(query: str, chunks: List[Dict]) -> Optional[str]:
+    if not chunks or not DIRECT_RULE_TERMS_RE.search(query or ""):
+        return None
+
+    terms = _query_terms(query)
+    if not terms:
+        return None
+
+    def chunk_score(chunk: Dict) -> int:
+        haystack = f"{chunk.get('source', '')} {chunk.get('article', '')} {chunk.get('text', '')}"
+        return sum(1 for term in terms if term in haystack)
+
+    ranked = sorted(chunks, key=chunk_score, reverse=True)
+    for chunk in ranked[:3]:
+        text = chunk.get("text", "")
+        label = _source_label(chunk)
+        sentences = _split_rule_sentences(text)
+
+        scored_sentences = []
+        for idx, sentence in enumerate(sentences):
+            if ARTICLE_HEADING_RE.match(sentence) and idx + 1 < len(sentences):
+                sentence = f"{sentence} {sentences[idx + 1]}"
+            score = sum(1 for term in terms if term in sentence)
+            if DIRECT_RULE_TERMS_RE.search(sentence):
+                score += 2
+            if score > 0:
+                scored_sentences.append((score, sentence))
+
+        if scored_sentences:
+            scored_sentences.sort(key=lambda item: item[0], reverse=True)
+            snippet = _clean_text(scored_sentences[0][1])
+            return f"{label}에 따르면, {snippet} (출처: {label})"
+
+        if chunk_score(chunk) >= max(1, min(2, len(terms))):
+            snippet = _clean_text(text)
+            return f"관련 조문은 {label}입니다. 확인된 내용: {snippet} (출처: {label})"
+
+    return None
+
+
+def _fallback_answer_from_chunks(chunks: List[Dict]) -> str:
+    if not chunks:
+        return "해당 규정을 찾을 수 없습니다."
+    lines = []
+    for chunk in chunks[:2]:
+        label = _source_label(chunk)
+        snippet = _clean_text(chunk.get("text", ""), max_chars=220)
+        lines.append(f"- {label}: {snippet}")
+    return "확인된 규정집 자료 기준으로 관련 조문은 다음과 같습니다.\n" + "\n".join(lines)
+
+
 async def generate(state: RuleState) -> RuleState:
     if state.get("error") and not state.get("chunks"):
         return {**state, "answer": "규정집 검색 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."}
@@ -48,9 +135,13 @@ async def generate(state: RuleState) -> RuleState:
     if not chunks:
         return {**state, "answer": "해당 규정을 찾을 수 없습니다."}
 
+    direct_answer = _direct_answer_from_chunks(state["query"], chunks)
+    if direct_answer:
+        return {**state, "answer": direct_answer}
+
     context_parts = []
-    for c in chunks:
-        text = c['text'][:300]
+    for c in chunks[:LLM_TOP_K]:
+        text = c['text'][:450]
         context_parts.append(f"[출처: {c['source']} {c['article']}]\n{text}")
     context = "\n\n".join(context_parts)
 
@@ -65,14 +156,17 @@ async def generate(state: RuleState) -> RuleState:
     user_prompt = f"질문: {state['query']}\n\n<규정집 내용>\n{context}\n</규정집 내용>"
 
     try:
-        resp = await _async_client.chat.completions.create(
-            model=OSS_MODEL,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user",   "content": user_prompt},
-            ],
-            temperature=0.2,
-            max_tokens=1024,
+        resp = await asyncio.wait_for(
+            _async_client.chat.completions.create(
+                model=OSS_MODEL,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user",   "content": user_prompt},
+                ],
+                temperature=0.2,
+                max_tokens=LLM_MAX_TOKENS,
+            ),
+            timeout=LLM_TIMEOUT_SECONDS,
         )
         choice = resp.choices[0]
         finish_reason = choice.finish_reason
@@ -84,7 +178,7 @@ async def generate(state: RuleState) -> RuleState:
         return {**state, "answer": answer}
     except Exception as e:
         logger.exception("LLM 답변 생성 중 오류 발생: %s", e)
-        return {**state, "answer": "답변 생성 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."}
+        return {**state, "answer": _fallback_answer_from_chunks(chunks)}
 
 
 def _build_graph():

--- a/LLM/sub_model/query_index.py
+++ b/LLM/sub_model/query_index.py
@@ -340,7 +340,7 @@ def confident_search_answer(query: str, top_k: int = 3) -> dict | None:
     top = hits.iloc[0]
     top_score = float(top.get("score", 0.0) or 0.0)
     second_score = float(hits.iloc[1].get("score", 0.0) or 0.0) if len(hits) > 1 else 0.0
-    if top_score < CONFIDENT_SCORE_THRESHOLD and (top_score - second_score) < CONFIDENT_SCORE_GAP:
+    if top_score < CONFIDENT_SCORE_THRESHOLD or (top_score - second_score) < CONFIDENT_SCORE_GAP:
         return None
 
     text = _clean_snippet(_answer_text_from_row(top))

--- a/LLM/sub_model/query_index.py
+++ b/LLM/sub_model/query_index.py
@@ -54,6 +54,9 @@ YEAR_PROGRAM_CREDIT_RE = re.compile(r"([23])\s*년제\s*(\d{2,3})")
 CONTACT_SEARCH_POOL_SIZE = 30
 GRAD_SEARCH_POOL_SIZE = 25
 GENERAL_SEARCH_POOL_SIZE = 12
+DIRECT_SNIPPET_MAX_CHARS = 220
+CONFIDENT_SCORE_THRESHOLD = 0.72
+CONFIDENT_SCORE_GAP = 0.08
 DEFAULT_DENSE_WEIGHT = 0.6
 CONTACT_DOC_BOOST = 0.18
 PHONE_EMAIL_BONUS_RATIO = 0.5
@@ -195,6 +198,158 @@ def _extract_grad_credits_from_text(text: str):
 def _looks_like_grad_query(q: str) -> bool:
     ql = (q or "").lower()
     return any(k in q or k in ql for k in GRAD_KWS)
+
+def _compact(s: str) -> str:
+    return re.sub(r"\s+", "", (s or "").lower())
+
+def _query_terms(query: str):
+    stop = set(CONTACT_KWS) | {
+        "알려줘", "찾아줘", "뭐야", "무엇", "어디", "어떻게", "관련", "정보", "안내",
+        "전화번호", "전화", "번호", "연락처", "문의", "상담", "담당자",
+    }
+    terms = []
+    for token in re.findall(HANGUL_TOKEN_PATTERN, query or ""):
+        if len(token) < 2 or token in stop:
+            continue
+        terms.append(token)
+    return list(dict.fromkeys(terms))
+
+def _source_suffix(row) -> str:
+    title = (row.get("title") or "").strip()
+    url = (row.get("url") or "").strip()
+    if title and url:
+        return f" (출처: {title} · {url})"
+    if url:
+        return f" (출처: {url})"
+    if title:
+        return f" (출처: {title})"
+    return ""
+
+def _clean_snippet(text: str, max_chars: int = DIRECT_SNIPPET_MAX_CHARS) -> str:
+    text = re.sub(r"\s+", " ", _preclean_text(text)).strip()
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars].rstrip() + "..."
+
+def _metadata_contact_answer(query: str) -> dict | None:
+    if not any(k in query for k in CONTACT_KWS):
+        return None
+
+    terms = _query_terms(query)
+    target_unit = _canonical_unit_from_query(query)
+    match_terms = [target_unit] if target_unit else terms[:3]
+    if not match_terms:
+        return None
+
+    rows = search_df[search_df["doc_type"].eq("contact")].copy()
+    if rows.empty:
+        return None
+
+    compact_terms = [_compact(term) for term in match_terms if term]
+    if not compact_terms:
+        return None
+
+    def score_row(row) -> int:
+        unit = _compact(row.get("unit", ""))
+        title = _compact(row.get("title", ""))
+        text = _compact(_answer_text_from_row(row))
+        score = 0
+        for term in compact_terms:
+            if term and term in unit:
+                score += 5
+            if term and term in title:
+                score += 3
+            if term and term in text:
+                score += 1
+        if (row.get("phone") or "").strip():
+            score += 2
+        if (row.get("email") or "").strip():
+            score += 1
+        return score
+
+    rows["_direct_score"] = rows.apply(score_row, axis=1)
+    rows = rows[rows["_direct_score"] >= 5].sort_values("_direct_score", ascending=False)
+    if rows.empty:
+        return None
+
+    lines, seen = [], set()
+    for _, row in rows.head(3).iterrows():
+        label = (row.get("unit") or row.get("title") or "요청하신 부서").strip()
+        phone = (row.get("phone") or "").strip()
+        email = (row.get("email") or "").strip()
+        key = (label, phone, email)
+        if key in seen:
+            continue
+        seen.add(key)
+        if phone:
+            lines.append(f"{label} 전화번호는 {phone}입니다{_source_suffix(row)}")
+        elif email:
+            lines.append(f"{label} 이메일은 {email}입니다{_source_suffix(row)}")
+        if lines:
+            break
+
+    if not lines:
+        return None
+    return {"answer": "\n".join(lines), "url": rows.iloc[0].get("url", "")}
+
+def _metadata_grad_answer(query: str) -> dict | None:
+    if not _looks_like_grad_query(query):
+        return None
+
+    rows = search_df[
+        search_df["has_credit"].astype(bool)
+        & search_df["doc_type"].isin(["policy", "table_like", "page", "department"])
+    ].copy()
+    if rows.empty:
+        return None
+
+    rows["_direct_score"] = (
+        rows["title"].astype(str).str.contains("졸업|학점|이수", regex=True).astype(int) * 3
+        + rows[ANSWER_TEXT_COL].astype(str).str.contains("졸업|이수|학점", regex=True).astype(int)
+    )
+    rows = rows[rows["_direct_score"] > 0].sort_values("_direct_score", ascending=False)
+
+    for _, row in rows.head(20).iterrows():
+        text = _answer_text_from_row(row)
+        total, parts = _extract_grad_credits_from_text(text)
+        if not total and not parts:
+            continue
+        lines = []
+        if total:
+            lines.append(f"총 졸업학점은 {total}학점입니다.")
+        if parts:
+            lines.append("세부 기준은 " + " / ".join(f"{k} {v}학점" for k, v in parts.items()) + "입니다.")
+        lines.append(_source_suffix(row).strip())
+        return {"answer": "\n".join(part for part in lines if part), "url": row.get("url", "")}
+    return None
+
+def metadata_direct_answer(query: str) -> dict | None:
+    """Answer high-confidence lookup questions without embedding or LLM calls."""
+    for resolver in (_metadata_contact_answer, _metadata_grad_answer):
+        answer = resolver(query)
+        if answer:
+            return answer
+    return None
+
+def confident_search_answer(query: str, top_k: int = 3) -> dict | None:
+    """Return a compact source-grounded answer when retrieval confidence is strong enough."""
+    hits = hybrid_search(query, top_k=max(top_k, 3))
+    if hits.empty or "score" not in hits.columns:
+        return None
+
+    top = hits.iloc[0]
+    top_score = float(top.get("score", 0.0) or 0.0)
+    second_score = float(hits.iloc[1].get("score", 0.0) or 0.0) if len(hits) > 1 else 0.0
+    if top_score < CONFIDENT_SCORE_THRESHOLD and (top_score - second_score) < CONFIDENT_SCORE_GAP:
+        return None
+
+    text = _clean_snippet(_answer_text_from_row(top))
+    if not text:
+        return None
+
+    title = (top.get("title") or "확인된 자료").strip()
+    answer = f"확인된 자료 기준으로는 {title}에 다음 내용이 있습니다: {text}{_source_suffix(top)}"
+    return {"answer": answer, "url": top.get("url", "")}
 
 def _extract_3yr_from_tables(text: str):
     t = _preclean_text(text)

--- a/LLM/sub_model/schedule_index.py
+++ b/LLM/sub_model/schedule_index.py
@@ -193,6 +193,11 @@ def schedule_search(query: str, top_k=8, today=None):
         df1 = df1[(df1["start_date"] <= pd.Timestamp(e)) & (df1["end_date"] >= pd.Timestamp(s))]
 
     tag_need = tags_for_query(query)
+    commencement_query = "COMMENCEMENT" in tag_need
+    semester_end_query = "SEMESTER_END" in tag_need
+    if semester_end_query:
+        tag_need.discard("SEMESTER_END")
+        tag_need.add("FINAL")
 
     if tag_need:
         df1 = df1[df1["tags"].apply(lambda s: bool(s & tag_need))]
@@ -216,16 +221,39 @@ def schedule_search(query: str, top_k=8, today=None):
     today_ts = pd.Timestamp(today)
 
     if sort_mode == "chronological":
-        df1 = df1.sort_values(by=["start_date", "end_date", "일정명"], ascending=[True, True, True])
+        if commencement_query:
+            df1["_is_late_commencement"] = df1["일정명"].astype(str).str.contains("후기")
+            df1 = df1.sort_values(
+                by=["_is_late_commencement", "start_date", "end_date", "일정명"],
+                ascending=[True, True, True, True],
+            )
+        else:
+            df1 = df1.sort_values(by=["start_date", "end_date", "일정명"], ascending=[True, True, True])
     elif sort_mode in ("reverse", "reverse_chronological", "desc"):
-        df1 = df1.sort_values(by=["start_date", "end_date", "일정명"], ascending=[False, False, True])
+        if commencement_query:
+            df1["_is_late_commencement"] = df1["일정명"].astype(str).str.contains("후기")
+            df1 = df1.sort_values(
+                by=["_is_late_commencement", "start_date", "end_date", "일정명"],
+                ascending=[True, False, False, True],
+            )
+        else:
+            df1 = df1.sort_values(by=["start_date", "end_date", "일정명"], ascending=[False, False, True])
     else:
         df1["_is_future"] = (df1["start_date"] >= today_ts)
-        df1 = df1.sort_values(by=["_is_future", "start_date"], ascending=[False, True])
+        if commencement_query:
+            df1["_is_late_commencement"] = df1["일정명"].astype(str).str.contains("후기")
+            df1 = df1.sort_values(
+                by=["_is_late_commencement", "_is_future", "start_date"],
+                ascending=[True, False, True],
+            )
+        else:
+            df1 = df1.sort_values(by=["_is_future", "start_date"], ascending=[False, True])
 
     def _fmt(r):
         s = r["start_date"].date().isoformat()
         e = r["end_date"].date().isoformat()
+        if semester_end_query and "FINAL" in r["tags"]:
+            return f"- 종강(기말고사 종료일): {e}"
         when = s if s == e else f"{s} ~ {e}"
         return f"- {r['일정명']}: {when}"
 

--- a/LLM/sub_model/schedule_rules.py
+++ b/LLM/sub_model/schedule_rules.py
@@ -10,8 +10,8 @@ class ScheduleTagRule:
 
 
 SCHEDULE_TAG_RULES = (
-    ScheduleTagRule("MIDTERM", re.compile(r"중간"), ("중간",)),
-    ScheduleTagRule("FINAL", re.compile(r"기말"), ("기말",)),
+    ScheduleTagRule("MIDTERM", re.compile(r"중간"), ("중간", "중간고사")),
+    ScheduleTagRule("FINAL", re.compile(r"기말|학기말\s*고사"), ("기말", "기말고사", "학기말", "학기말고사")),
     ScheduleTagRule("REGISTRATION", re.compile(r"수강\s*신청|예비\s*수강"), ("수강",)),
     ScheduleTagRule("ADD_DROP", re.compile(r"수강\s*정정|정정"), ("정정",)),
     ScheduleTagRule("GRADE", re.compile(r"성적|성적공시|성적입력|성적열람|성적정정"), ("성적",)),
@@ -21,7 +21,7 @@ SCHEDULE_TAG_RULES = (
     ScheduleTagRule("SEMESTER_END", re.compile(r"종강"), ("종강",)),
     ScheduleTagRule("HOLIDAY", re.compile(r"휴일|공휴일|추석|설날|현충일|한글날|크리스마스"), ("휴일", "공휴")),
     ScheduleTagRule("CLASSDAY", re.compile(r"수업일수|수업"), ("수업", "수업일수")),
-    ScheduleTagRule("COMMENCEMENT", re.compile(r"졸업식|학위수여식"), ("졸업식", "학위수여식")),
+    ScheduleTagRule("COMMENCEMENT", re.compile(r"졸업식|학위수여식"), ("졸업식", "종업식", "학위수여식")),
 )
 
 SCHEDULE_BASE_HINTS = (
@@ -56,6 +56,8 @@ def tags_for_query(query: str) -> set[str]:
     for rule in SCHEDULE_TAG_RULES:
         if any(keyword in source for keyword in rule.query_keywords):
             tags.add(rule.tag)
+    if {"MIDTERM", "FINAL"}.isdisjoint(tags) and any(keyword in source for keyword in ("시험", "고사")):
+        tags.update({"MIDTERM", "FINAL"})
     if "수강" in source and "정정" in source:
         tags.discard("REGISTRATION")
         tags.add("ADD_DROP")

--- a/LLM/sub_model/schedule_rules.py
+++ b/LLM/sub_model/schedule_rules.py
@@ -56,7 +56,7 @@ def tags_for_query(query: str) -> set[str]:
     for rule in SCHEDULE_TAG_RULES:
         if any(keyword in source for keyword in rule.query_keywords):
             tags.add(rule.tag)
-    if {"MIDTERM", "FINAL"}.isdisjoint(tags) and any(keyword in source for keyword in ("시험", "고사")):
+    if not tags and any(keyword in source for keyword in ("시험", "고사")):
         tags.update({"MIDTERM", "FINAL"})
     if "수강" in source and "정정" in source:
         tags.discard("REGISTRATION")

--- a/tests/regression/chatbot_regression_cases.json
+++ b/tests/regression/chatbot_regression_cases.json
@@ -12,6 +12,12 @@
     "all_of_text_contains": ["일정", "+"]
   },
   {
+    "id": "schedule_commencement_25_calendar_year",
+    "text": "25년도 졸업식 알려줘",
+    "engine_in": ["fast"],
+    "all_of_text_contains": ["2025-02-21"]
+  },
+  {
     "id": "contact_cs_fullname",
     "text": "컴퓨터공학부 담당자 연락처",
     "engine_in": ["fast"],


### PR DESCRIPTION
## 관련 이슈

Close #102 

## 🎯 배경

- 챗봇 학사일정 질의에서 시험기간, 종강, 졸업식/학위수여식 관련 답변이 사용자 의도와 다르게 검색되거나 OSS 응답으로 넘어가는 문제가 있었습니다.
- OSS 호출이 느릴 때 짧은 추가 입력까지 로딩 상태로 쌓이는 현상을 완화할 필요가 있었습니다.

## 🔍 주요 내용

- 시험기간 질의가 중간고사와 기말고사를 함께 반환하도록 일정 태그 규칙을 보강했습니다.
- 종강 질의는 기말고사 종료일 기준으로 응답하도록 처리했습니다.
- 졸업식/학위수여식 질의에서 후기 학위수여식을 뒤로 정렬하고, 일정 검색을 우선하도록 조정했습니다.
- 종업식 오타를 졸업식 의도로 처리하도록 추가했습니다.
- OSS 호출을 별도 executor로 분리하고, 2글자 이하 짧은 OSS 입력은 즉시 안내 응답하도록 개선했습니다.
- 일정명 안의 시간 표기(11:00) 때문에 포맷터가 일정을 누락하던 정규식 문제를 수정했습니다.
- 25년도 졸업식 알려줘 회귀 케이스를 추가했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 변경 요약
챗봇이 메타데이터 기반 응답을 우선하고, 시험/졸업식 관련 스케줄 처리와 OSS 호출 흐름을 개선했습니다. 정규식 버그 수정과 회귀 테스트도 추가되었습니다.

## 주요 변경점
- "종업식" 오타를 졸업식 의도로 매핑해 동의어로 처리(CEREMONY_RE, schedule_rules)
- 메타데이터 우선 응답 도입: metadata_direct_answer(), confident_search_answer()로 연락처·학점 등 직접 추출
- OSS 호출 분리 및 비동기화: call_oss_async() 추가, 2자 이하 입력은 바로 인사/안내로 처리해 블로킹 방지
- 스케줄 규칙 강화: 중간/기말 키워드 확장 및 시험 쿼리 시 MIDTERM+FINAL 동시 반환, 종강은 기말 종료일 사용
- 정규식 개선: SCHED_LINE_PATTERN 타이틀 캡처를 non-greedy로 변경해 시간 표기(예: "11:00")로 인한 파싱 누락 해결
- rule_book 및 검색 로직 개선: 직접 답변 우선화, LLM 타임아웃/토큰 제한 추가, 검색 기반 구조화 폴백 응답 제공
- 회귀 테스트 추가: "25년도 졸업식 알려줘" 케이스(2025-02-21 포함)

## 주의/리스크
- non-greedy 타이틀 캡처로 인해 일부 타이틀 분할이 달라질 수 있음(콜론 위치 의존)
- 메타데이터 기반 응답은 인덱스된 문서 품질에 따라 오답 위험 존재
- OSS 비동기/타임아웃 변화로 동시성·타임아웃 엣지케이스 모니터링 필요

## 다음 액션
- 졸업식/종업식 관련 실제 쿼리로 응답 순서 및 후기 학위수여식 배치 검증
- 메타데이터 추출(학점·연락처) 정확도와 인덱스 품질 점검
- OSS 짧은 입력 안내 메시지 UX 적합성 검토 및 필요 시 안내 문구 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->