### PR TITLE
fix: oci docker build database error fixed

### DIFF
--- a/LLM/OSS/service.py
+++ b/LLM/OSS/service.py
@@ -97,8 +97,11 @@ def init_db_pool() -> None:
                 tunnel_db_kwargs["port"],
             )
             return
-        except ConfigurationError:
-            raise
+        except ConfigurationError as exc:
+            connection_errors.append(exc)
+            if settings.db_host is None:
+                raise
+            logger.warning("chatbot_ssh_db_config_invalid fallback_to_direct=true error=%s", exc)
         except Exception as exc:
             connection_errors.append(exc)
             if _ssh_tunnel:


### PR DESCRIPTION
## 관련 이슈

Close #102 

## 🎯 배경

- 도커 빌드 후 OCI 서버에서 db connect 에러 해결이 필요합니다.

## 🔍 주요 내용

- 로컬 테스트를 위한 ssh database -> 내부 database -> local database 순서로 변경
