### PR TITLE
feat: chatbot profanity filter settings add

### DIFF
--- a/LLM/OSS/service.py
+++ b/LLM/OSS/service.py
@@ -235,6 +235,10 @@ async def should_block_profanity(user_text: str) -> bool:
         logger.warning("chatbot_profanity_filter_failed fail_open=true error=%s", exc)
         return False
 
+    if not isinstance(payload, dict):
+        logger.warning("chatbot_profanity_filter_invalid_response fail_open=true")
+        return False
+
     results = payload.get("results", [])
     if not isinstance(results, list):
         logger.warning("chatbot_profanity_filter_invalid_response fail_open=true")

--- a/LLM/OSS/service.py
+++ b/LLM/OSS/service.py
@@ -8,6 +8,7 @@ from functools import partial
 from pathlib import Path
 from typing import Optional
 
+import httpx
 from cachetools import TTLCache
 from openai import OpenAI
 from psycopg2 import pool as pg_pool
@@ -53,6 +54,8 @@ _oss_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="chatbot_os
 
 _client: Optional[OpenAI] = None
 _client_lock = threading.Lock()
+
+PROFANITY_GUARD_TEXT = "부적절한 표현이 포함되어 답변하기 어려워요. 질문을 순화해서 다시 입력해 주세요."
 
 
 class ChatReq(BaseModel):
@@ -217,6 +220,28 @@ async def call_oss_async(messages: list[dict[str, str]], **kwargs) -> str:
     return await loop.run_in_executor(_oss_executor, partial(call_oss, messages, **kwargs))
 
 
+async def should_block_profanity(user_text: str) -> bool:
+    if not settings.chatbot_profanity_filter_enabled or not settings.text_filter_api_url:
+        return False
+    if not (user_text or "").strip():
+        return False
+
+    try:
+        async with httpx.AsyncClient(timeout=settings.text_filter_api_timeout) as client:
+            response = await client.post(settings.text_filter_api_url, json={"text": user_text})
+            response.raise_for_status()
+            payload = response.json()
+    except Exception as exc:
+        logger.warning("chatbot_profanity_filter_failed fail_open=true error=%s", exc)
+        return False
+
+    results = payload.get("results", [])
+    if not isinstance(results, list):
+        logger.warning("chatbot_profanity_filter_invalid_response fail_open=true")
+        return False
+    return any(str(label).strip() == "비속어" for label in results)
+
+
 def call_submodel(user_text: str) -> str:
     base = ""
     try:
@@ -262,6 +287,11 @@ async def chat_with_oss(req: ChatReq) -> dict:
     user_text = extract_user_text(req)
     messages_for_oss = ensure_messages(req, user_text)
     compact_user_text = "".join(user_text.split())
+
+    if await should_block_profanity(user_text):
+        latency = int((time.monotonic() - start) * 1000)
+        _log_executor.submit(_log_chatbot, user_text, "guard", PROFANITY_GUARD_TEXT, None, False, latency)
+        return {"engine": "guard", "text": PROFANITY_GUARD_TEXT}
 
     if GOVERNANCE_REMOVE_RE.search(user_text) and GOVERNANCE_TARGET_RE.search(user_text):
         return {

--- a/core/settings.py
+++ b/core/settings.py
@@ -26,6 +26,9 @@ class Settings:
     oss_api_key: str | None
     oss_model: str | None
     json_only_mode: bool
+    chatbot_profanity_filter_enabled: bool
+    text_filter_api_url: str | None
+    text_filter_api_timeout: float
     root_base_path: str | None
     dept_map_path: str | None
     ssh_host: str | None
@@ -84,6 +87,9 @@ def get_settings() -> Settings:
         oss_api_key=os.getenv("OSS_API_KEY"),
         oss_model=os.getenv("OSS_MODEL"),
         json_only_mode=os.getenv("JSON_ONLY_MODE", "0").strip() == "1",
+        chatbot_profanity_filter_enabled=os.getenv("CHATBOT_PROFANITY_FILTER_ENABLED", "0").strip() == "1",
+        text_filter_api_url=os.getenv("TEXT_FILTER_API_URL"),
+        text_filter_api_timeout=float(os.getenv("TEXT_FILTER_API_TIMEOUT", "1.0")),
         root_base_path=os.getenv("ROOT_BASE_PATH"),
         dept_map_path=os.getenv("DEPT_MAP_PATH"),
         ssh_host=os.getenv("SSH_HOST"),

--- a/core/settings.py
+++ b/core/settings.py
@@ -9,6 +9,17 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
+def _get_float_env(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
 @dataclass(frozen=True)
 class Settings:
     secret_key: str | None
@@ -89,7 +100,7 @@ def get_settings() -> Settings:
         json_only_mode=os.getenv("JSON_ONLY_MODE", "0").strip() == "1",
         chatbot_profanity_filter_enabled=os.getenv("CHATBOT_PROFANITY_FILTER_ENABLED", "0").strip() == "1",
         text_filter_api_url=os.getenv("TEXT_FILTER_API_URL"),
-        text_filter_api_timeout=float(os.getenv("TEXT_FILTER_API_TIMEOUT", "1.0")),
+        text_filter_api_timeout=_get_float_env("TEXT_FILTER_API_TIMEOUT", 1.0),
         root_base_path=os.getenv("ROOT_BASE_PATH"),
         dept_map_path=os.getenv("DEPT_MAP_PATH"),
         ssh_host=os.getenv("SSH_HOST"),


### PR DESCRIPTION
## 관련 이슈

Open #105 

## 🎯 배경

- 챗봇 입력에 비속어 필터링을 적용해 부적절한 질문이 RAG/LLM 처리로 넘어가기 전에 차단할 필요가 있습니다.
- 기존 텍스트 필터링 서비스와 챗봇 서비스의 분리 구조를 유지하면서, 챗봇 컨테이너에 ML 모델을 중복 탑재하지 않는 방식이 필요했습니다.

## 🔍 주요 내용

- 챗봇 요청 초반에 텍스트 필터 API를 호출하는 입력 가드를 추가했습니다.
- 필터 API 결과에 `비속어`가 포함되면 `guard` 엔진 응답으로 차단합니다.
- 필터 API 장애/타임아웃/비정상 응답 시 기존 챗봇 흐름을 유지하는 fail-open 정책을 적용했습니다.
- `CHATBOT_PROFANITY_FILTER_ENABLED`, `TEXT_FILTER_API_URL`, `TEXT_FILTER_API_TIMEOUT` 설정을 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 변경 요약(1~3줄)  
챗봇에 외부 텍스트 필터 기반 욕설 차단을 추가했습니다. 필터가 "비속어"를 반환하면 가드 응답으로 차단하고, 필터 오류/타임아웃 시에는 기존 흐름을 유지하는 fail-open 정책을 적용했습니다.

## 주요 변경점
- 외부 API 기반 필터 함수 추가: `should_block_profanity(user_text)`로 텍스트 필터 호출해 "비속어" 여부 판단
- 챗봇 흐름 조기 차단: `chat_with_oss`에서 사용자 텍스트 추출 후 즉시 필터 검사해 감지 시 `engine: "guard"` 응답 반환
- 설정 추가: CHATBOT_PROFANITY_FILTER_ENABLED, TEXT_FILTER_API_URL, TEXT_FILTER_API_TIMEOUT (설정 파싱용 _get_float_env 포함)
- 오류·타임아웃 처리 개선: 필터 호출 에러 전달 로직 및 서비스 페이로드 타입 검증 추가로 비정상 응답 대비
- 설계: 외부 텍스트 필터 서비스와 분리 유지하여 챗봇 컨테이너에 ML 중복 배포 방지

## 주의/리스크
- 외부 API 의존성으로 인한 지연/가용성 문제(타임아웃 설정으로 완화 가능)
- 필터 정확도에 따른 오탐/미탐 위험 — 정상 질문 차단 가능성 존재
- 잘못된/비정상 페이로드 처리 시 로그는 남지만 정책상 fail-open이므로 일부 부적절 문장이 통과할 수 있음

## 다음 액션
- 텍스트 필터 통합 테스트 및 운영 모니터링(오탐/오누락 수집)
- 타임아웃/재시도 정책 및 로깅(모니터링용) 검토
<!-- end of auto-generated comment: release notes by coderabbit.ai -->