### PR TITLE
fix: textfilter timeout standard value fixed

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -100,7 +100,7 @@ def get_settings() -> Settings:
         json_only_mode=os.getenv("JSON_ONLY_MODE", "0").strip() == "1",
         chatbot_profanity_filter_enabled=os.getenv("CHATBOT_PROFANITY_FILTER_ENABLED", "0").strip() == "1",
         text_filter_api_url=os.getenv("TEXT_FILTER_API_URL"),
-        text_filter_api_timeout=_get_float_env("TEXT_FILTER_API_TIMEOUT", 1.0),
+        text_filter_api_timeout=_get_float_env("TEXT_FILTER_API_TIMEOUT", 10.0),
         root_base_path=os.getenv("ROOT_BASE_PATH"),
         dept_map_path=os.getenv("DEPT_MAP_PATH"),
         ssh_host=os.getenv("SSH_HOST"),


### PR DESCRIPTION
## 관련 이슈

Close #105 

## 🎯 배경

- 챗봇 텍스트 필터링 적용 시 api 호출 시간이 짧아 타임아웃 현상이 발생을 해결합니다.

## 🔍 주요 내용

- `text_filter_api_timeout` 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 요약
챗봇 텍스트 필터링 API 호출 시 타임아웃 문제를 해결하기 위해 타임아웃 기본값을 1.0초에서 10.0초로 확대하고, 환경변수 파싱을 더 안전하게 개선했습니다.

## 주요 변경점
- `_get_float_env` 헬퍼 함수 추가로 환경변수를 안전하게 float로 파싱
- 유효하지 않은 값이나 음수는 기본값으로 대체하는 로직 구현
- `TEXT_FILTER_API_TIMEOUT` 기본값을 1.0초 → 10.0초로 변경
- `LLM/OSS/service.py`의 httpx AsyncClient 타임아웃 설정에 적용됨
- 설정 로딩 로직만 수정 (공개 API 변경 없음)

## 주의/리스크
- API 응답 대기 시간이 최대 10배 증가할 수 있으니 클라이언트 타임아웃 설정 확인 필요
- 환경변수로 별도 설정하지 않으면 항상 10초로 적용됨

## 다음 액션
- 실제 API 응답 시간이 개선되었는지 모니터링
- 필요시 환경변수(`TEXT_FILTER_API_TIMEOUT`)로 타임아웃 값을 커스터마이징 가능한지 테스트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->