### PR TITLE
chore: harden chatbot profanity guard dehavior

### DIFF
--- a/LLM/OSS/service.py
+++ b/LLM/OSS/service.py
@@ -221,10 +221,13 @@ async def call_oss_async(messages: list[dict[str, str]], **kwargs) -> str:
 
 
 async def should_block_profanity(user_text: str) -> bool:
-    if not settings.chatbot_profanity_filter_enabled or not settings.text_filter_api_url:
+    if not settings.chatbot_profanity_filter_enabled:
         return False
     if not (user_text or "").strip():
         return False
+    if not settings.text_filter_api_url:
+        logger.warning("chatbot_profanity_filter_missing_url fail_closed=true")
+        return True
 
     try:
         async with httpx.AsyncClient(timeout=settings.text_filter_api_timeout) as client:
@@ -232,17 +235,17 @@ async def should_block_profanity(user_text: str) -> bool:
             response.raise_for_status()
             payload = response.json()
     except Exception as exc:
-        logger.warning("chatbot_profanity_filter_failed fail_open=true error=%s", exc)
-        return False
+        logger.warning("chatbot_profanity_filter_failed fail_closed=true error=%s", exc)
+        return True
 
     if not isinstance(payload, dict):
-        logger.warning("chatbot_profanity_filter_invalid_response fail_open=true")
-        return False
+        logger.warning("chatbot_profanity_filter_invalid_response fail_closed=true")
+        return True
 
     results = payload.get("results", [])
     if not isinstance(results, list):
-        logger.warning("chatbot_profanity_filter_invalid_response fail_open=true")
-        return False
+        logger.warning("chatbot_profanity_filter_invalid_response fail_closed=true")
+        return True
     return any(str(label).strip() == "비속어" for label in results)
 
 


### PR DESCRIPTION
## 관련 이슈

Close #105 

## 🎯 배경

- 챗봇 비속어 필터가 활성화된 상태에서도 필터 API 장애가 발생하면 OSS 경로로 요청이 통과할 수 있었습니다.
- 부적절한 입력이 LLM으로 전달되지 않도록 필터 장애 시 차단하는 방식으로 보강했습니다.

## 🔍 주요 내용

- 챗봇 비속어 필터가 켜져 있을 때 `TEXT_FILTER_API_URL`이 없으면 guard 응답으로 차단합니다.
- 필터 API 호출 실패, timeout, 비정상 응답, 잘못된 응답 형식이 발생하면 fail-close로 차단합니다.
- 정상 필터 응답인 경우 기존처럼 `results`에 `비속어`가 포함될 때만 차단합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 요약
챗봇 비속어 필터의 안정성을 강화하여, 필터 API가 불가능하거나 오류가 발생할 때 요청을 차단하도록 변경되었습니다. 기존의 fail-open 방식에서 fail-close 방식으로 변경되어 부적절한 입력이 LLM에 도달하지 않도록 보호합니다.

## 주요 변경점
- **필터 API URL 미설정 시**: 필터가 활성화되어 있으면 요청을 블록하도록 변경
- **API 호출 실패 처리**: 네트워크 오류, 타임아웃, 비정상 응답 등 모든 실패 상황에서 요청을 차단
- **응답 형식 검증**: JSON 파싱 실패나 `results` 필드가 리스트가 아닌 경우 차단
- **정상 응답 처리**: API 응답이 정상인 경우 기존 로직 유지 (결과에 "비속어" 포함 시만 차단)
- **입력 유효성**: 필터 비활성화 또는 빈 입력값인 경우 명시적으로 `False` 반환
- **실패 안전 철학**: fail-close 원칙으로 예외 상황에서도 안전하게 차단

## 주의/리스크
- 필터 API 장애 시 정상 요청도 블록될 수 있으므로, API 안정성 모니터링 필요
- 필터 비활성화 시나 필터 API 호출 전에 권한 검증 로직이 있는지 확인 필요
- 사용자 경험에 영향을 줄 수 있으므로 필터 API 가용성에 대한 대응 계획 필요

## 다음 액션
- 관련 이슈 #105 검토 및 논의 상태 확인
- 필터 API의 안정성 및 응답 시간 최적화 검토
- 필터 차단으로 인한 사용자 피드백 메커니즘 구축

<!-- end of auto-generated comment: release notes by coderabbit.ai -->