### PR TITLE
feat: add rag retrieval evaluation dataset

### DIFF
--- a/.github/workflows/rag-light-check.yml
+++ b/.github/workflows/rag-light-check.yml
@@ -1,0 +1,55 @@
+name: RAG Light Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+
+jobs:
+  rag-light-check:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'run-rag-check')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install lightweight regression dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install numpy pandas pyarrow python-dotenv
+
+      - name: Validate RAG eval case JSON
+        run: python -m json.tool tests/regression/rag_eval_cases.json > /tmp/rag_eval_cases.formatted.json
+
+      - name: Compile RAG regression scripts
+        run: |
+          python -m py_compile \
+            tests/regression/evaluate_rag_retrieval.py \
+            tests/regression/check_query_index_compat.py \
+            tests/regression/check_query_index_metadata_quality.py \
+            LLM/sub_model/query_index.py
+
+      - name: Run lightweight query-index compatibility checks
+        run: |
+          python tests/regression/check_query_index_compat.py
+          python tests/regression/check_query_index_metadata_quality.py
+
+      - name: Write summary
+        if: always()
+        run: |
+          {
+            echo "## RAG Light Check"
+            echo ""
+            echo "- Triggered by: \`${{ github.event_name }}\`"
+            echo "- PR label required: \`run-rag-check\`"
+            echo "- Checks: JSON validation, Python compile, lightweight query-index regressions"
+            echo ""
+            echo "This workflow does not run the full local model-backed 30-case RAG evaluation."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/LLM/sub_model/query_index.py
+++ b/LLM/sub_model/query_index.py
@@ -29,7 +29,9 @@ THIS_DIR = Path(__file__).resolve().parent
 ROOT_DIR = THIS_DIR.parent.parent
 
 # 졸업학점 관련 키워드 복원 (학교 기본 정보 포함)
-GRAD_KWS = ["졸업", "졸업학점", "졸업 학점", "졸업요건", "졸업요구학점", "이수학점", "졸업 이수학점"]
+GRAD_KWS = ["졸업학점", "졸업 학점", "졸업요건", "졸업요구학점", "이수학점", "졸업 이수학점"]
+GRAD_CREDIT_QUERY_RE = re.compile(r"(졸업\s*학점|졸업\s*(?:요건|요구|기준)|졸업\s*이수|이수\s*학점|3\s*년제)")
+GRAD_NON_CREDIT_POLICY_RE = re.compile(r"(졸업보류|졸업유예|졸업연기)")
 FAX_RE = re.compile(r"(?:팩스|FAX)", re.I)
 GENERIC_LABEL_RE = GENERIC_ORG_LABEL_RE
 
@@ -196,8 +198,32 @@ def _extract_grad_credits_from_text(text: str):
     return total, parts
 
 def _looks_like_grad_query(q: str) -> bool:
-    ql = (q or "").lower()
-    return any(k in q or k in ql for k in GRAD_KWS)
+    text = q or ""
+    if GRAD_NON_CREDIT_POLICY_RE.search(text) and not re.search(r"(학점|이수)", text):
+        return False
+    ql = text.lower()
+    compact = _compact(text)
+    return (
+        bool(GRAD_CREDIT_QUERY_RE.search(text))
+        or ("졸업" in compact and "학점" in compact)
+        or any(k in text or k in ql for k in GRAD_KWS)
+    )
+
+def _query_match_terms(query: str) -> list[str]:
+    stop = {
+        "안내", "관련", "정보", "알려줘", "찾아줘", "뭐야", "무엇", "어디", "어떻게",
+        "신청", "기준", "절차", "페이지",
+    }
+    terms = []
+    for token in re.findall(HANGUL_TOKEN_PATTERN, query or ""):
+        if len(token) < 2 or token in stop:
+            continue
+        terms.append(token)
+    return list(dict.fromkeys(terms))
+
+def _text_match_score(text: str, terms: list[str]) -> int:
+    compact_text = _compact(text)
+    return sum(1 for term in terms if _compact(term) and _compact(term) in compact_text)
 
 def _compact(s: str) -> str:
     return re.sub(r"\s+", "", (s or "").lower())
@@ -566,12 +592,31 @@ def build_answer(query, top_k=6):
 
         hits = hybrid_search(query, top_k=max(top_k, GRAD_SEARCH_POOL_SIZE))
         urls = hits["url"].fillna("")
+        titles = hits["title"].fillna("")
+        leaf_titles = hits.get("leaf_title", pd.Series([""]*len(hits))).fillna("")
+        breadcrumbs = hits.get("breadcrumb", pd.Series([""]*len(hits))).fillna("")
         home_like = urls.str.contains(HOME_LIKE_URL_PATTERN, case=False, regex=True)
         bbs_like  = urls.str.contains(BOARD_URL_PATTERN, case=False, regex=True)
         is_page   = hits["doc_type"].isin(["page", "policy", "table_like", "department"])
+        terms = _query_match_terms(query)
+        title_term_match = titles.map(lambda s: _text_match_score(s, terms))
+        leaf_term_match = leaf_titles.map(lambda s: _text_match_score(s, terms))
+        breadcrumb_term_match = breadcrumbs.map(lambda s: _text_match_score(s, terms))
+        professional_match = pd.Series([0] * len(hits))
+        if "전문학사" in query:
+            professional_match = titles.str.contains("전문학사", regex=False).astype(int) * 3
+        elif "학사" in query and "전문학사" not in query:
+            professional_match = (
+                titles.str.contains("학사", regex=False)
+                & ~titles.str.contains("전문학사", regex=False)
+            ).astype(int) * 2
         rr = (
             HOME_PAGE_RERANK_BOOST * home_like.astype(int)
             + PAGE_DOC_RERANK_BOOST * is_page.astype(int)
+            + TITLE_UNIT_MATCH_BOOST * 2.0 * title_term_match
+            + TITLE_UNIT_MATCH_BOOST * 1.5 * leaf_term_match
+            + TITLE_UNIT_MATCH_BOOST * 0.8 * breadcrumb_term_match
+            + professional_match
             - BOARD_PAGE_PENALTY * bbs_like.astype(int)
         )
         hits = hits.assign(_rr=rr).sort_values(["_rr", "score"], ascending=[False, False])
@@ -627,17 +672,35 @@ def build_answer(query, top_k=6):
 
     if not hits.empty:
         urls = hits["url"].fillna("")
+        titles = hits["title"].fillna("")
+        leaf_titles = hits.get("leaf_title", pd.Series([""]*len(hits))).fillna("")
+        breadcrumbs = hits.get("breadcrumb", pd.Series([""]*len(hits))).fillna("")
         home_like = urls.str.contains(HOME_LIKE_URL_PATTERN, case=False, regex=True)
         bbs_like  = urls.str.contains(BOARD_URL_PATTERN, case=False, regex=True)
         is_page   = hits["doc_type"].isin(["page", "intro", "department", "policy", "table_like", "history"])
         def _n(s: str) -> str: return re.sub(r"\s+", "", (s or "").lower())
         qn = _n(query)
-        title_match = hits["title"].fillna("").map(lambda s: qn in _n(s))
+        title_match = titles.map(lambda s: qn in _n(s))
         unit_match  = hits.get("unit", pd.Series([""]*len(hits))).fillna("").map(lambda s: qn in _n(s))
+        terms = _query_match_terms(query)
+        title_term_match = titles.map(lambda s: _text_match_score(s, terms))
+        leaf_term_match = leaf_titles.map(lambda s: _text_match_score(s, terms))
+        breadcrumb_term_match = breadcrumbs.map(lambda s: _text_match_score(s, terms))
+        academic_policy_match = (
+            breadcrumbs.str.contains("학사안내", regex=False)
+            & ~titles.str.contains("센터|공지사항|동영상자료|보고절차", regex=True)
+            & hits["doc_type"].isin(["policy", "page", "history", "table_like"])
+        ).astype(int)
+        if any(k in query for k in ("센터", "연락처", "전화", "담당자")):
+            academic_policy_match = pd.Series([0] * len(hits))
         rr = (
             HOME_PAGE_RERANK_BOOST * home_like.astype(int)
           + PAGE_DOC_RERANK_BOOST * is_page.astype(int)
           + TITLE_UNIT_MATCH_BOOST * (title_match.astype(int) | unit_match.astype(int))
+          + TITLE_UNIT_MATCH_BOOST * 2.5 * title_term_match
+          + TITLE_UNIT_MATCH_BOOST * 2.0 * leaf_term_match
+          + TITLE_UNIT_MATCH_BOOST * 1.0 * breadcrumb_term_match
+          + TITLE_UNIT_MATCH_BOOST * 1.5 * academic_policy_match
           - BOARD_PAGE_PENALTY * bbs_like.astype(int)
         )
         hits = hits.assign(_rr=rr).sort_values(["_rr", "score"], ascending=[False, False])

--- a/scripts/check_rag_eval.sh
+++ b/scripts/check_rag_eval.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+REPORT_PATH="${RAG_EVAL_REPORT_PATH:-/tmp/rag_eval_report.json}"
+CONDA_ENV="${RAG_EVAL_CONDA_ENV:-dl_study}"
+
+HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+conda run -n "$CONDA_ENV" python tests/regression/evaluate_rag_retrieval.py \
+  --out "$REPORT_PATH" \
+  --fail-on-fail
+
+conda run -n "$CONDA_ENV" python tests/regression/check_query_index_compat.py
+conda run -n "$CONDA_ENV" python tests/regression/check_query_index_metadata_quality.py
+
+echo "rag_eval_report=$REPORT_PATH"

--- a/tests/regression/evaluate_rag_retrieval.py
+++ b/tests/regression/evaluate_rag_retrieval.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import re
+import statistics
+import sys
+import time
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+DATE_RE = re.compile(r"\b20\d{2}-\d{2}-\d{2}\b")
+URL_RE = re.compile(r"https?://[^\s)>\]}\"']+")
+
+
+def load_cases(path: Path) -> list[dict]:
+    with path.open("r", encoding="utf-8") as f:
+        cases = json.load(f)
+    if not isinstance(cases, list):
+        raise ValueError("RAG eval cases must be a JSON array")
+    return cases
+
+
+def contains_any(text: str, needles: list[str]) -> bool:
+    if not needles:
+        return True
+    return any(needle and needle in text for needle in needles)
+
+
+def contains_all(text: str, needles: list[str]) -> bool:
+    return all(needle in text for needle in needles)
+
+
+def urls_from_hits(hits) -> list[str]:
+    if hits is None or getattr(hits, "empty", True) or "url" not in hits.columns:
+        return []
+    return [str(url or "") for url in hits["url"].head(10).tolist()]
+
+
+def url_contains(url: str, fragments: list[str]) -> bool:
+    return contains_any(url, fragments)
+
+
+def rank_for_expected_url(hits, fragments: list[str]) -> int | None:
+    if not fragments or hits is None or getattr(hits, "empty", True) or "url" not in hits.columns:
+        return None
+    for idx, url in enumerate(hits["url"].astype(str).tolist(), start=1):
+        if url_contains(url, fragments):
+            return idx
+    return None
+
+
+def title_matches(hits, fragments: list[str]) -> bool:
+    if not fragments or hits is None or getattr(hits, "empty", True) or "title" not in hits.columns:
+        return bool(not fragments)
+    top_title = str(hits.iloc[0].get("title", "") or "")
+    return contains_any(top_title, fragments)
+
+
+def hallucination_flags(answer: str, hits, expected_url_fragments: list[str]) -> list[str]:
+    """Detect obvious generated-source drift without treating extra official links as errors.
+
+    build_answer() may include reranked official school URLs beyond the metric top_k, so the
+    proxy only flags non-DMU URLs here. Stricter context-vs-answer checks belong in an API/LLM
+    evaluator where the exact prompt context is captured.
+    """
+    flags = []
+    allowed_urls = urls_from_hits(hits)
+    answer_urls = URL_RE.findall(answer or "")
+    for url in answer_urls:
+        if "dongyang.ac.kr" in url:
+            continue
+        if url in allowed_urls:
+            continue
+        if any(fragment and fragment in url for fragment in expected_url_fragments):
+            continue
+        flags.append(f"unknown_url:{url}")
+    return flags
+
+
+def evaluate_search_case(case: dict, top_k: int, answer_top_k: int) -> dict:
+    from LLM.sub_model.query_index import build_answer, hybrid_search
+
+    query = case.get("query", "")
+    started = time.perf_counter()
+    hits = hybrid_search(query, top_k=top_k)
+    retrieval_ms = round((time.perf_counter() - started) * 1000, 2)
+
+    answer_started = time.perf_counter()
+    answer_payload = build_answer(query, top_k=answer_top_k) or {}
+    answer_ms = round((time.perf_counter() - answer_started) * 1000, 2)
+
+    answer = str(answer_payload.get("answer", "") or "")
+    expected_urls = case.get("expected_url_contains", [])
+    url_rank = rank_for_expected_url(hits, expected_urls)
+    top1_url_match = url_rank == 1
+    top3_url_match = bool(url_rank and url_rank <= 3)
+    answer_url_match = contains_any(answer, expected_urls) if expected_urls else True
+    source_url_match = answer_url_match if case.get("requires_source_url", False) else True
+    answer_any = contains_any(answer, case.get("answer_must_contain_any", []))
+    answer_all = contains_all(answer, case.get("answer_must_contain_all", []))
+    date_pass = bool(DATE_RE.search(answer)) if case.get("requires_date", False) else True
+    hallu = hallucination_flags(answer, hits, expected_urls)
+
+    return {
+        "id": case.get("id"),
+        "category": case.get("category", ""),
+        "kind": "search",
+        "query": query,
+        "top1_url_match": top1_url_match,
+        "top3_url_match": top3_url_match,
+        "top1_title_match": title_matches(hits, case.get("expected_title_contains", [])),
+        "answer_keyword_match": answer_any and answer_all,
+        "source_url_match": source_url_match,
+        "date_match": date_pass,
+        "hallucination_detected": bool(hallu),
+        "hallucination_flags": hallu,
+        "expected_url_rank": url_rank,
+        "top1_title": str(hits.iloc[0].get("title", "") if not hits.empty else ""),
+        "top1_url": str(hits.iloc[0].get("url", "") if not hits.empty else ""),
+        "answer": answer,
+        "retrieval_latency_ms": retrieval_ms,
+        "answer_latency_ms": answer_ms,
+        "passed": all([
+            top3_url_match if expected_urls else True,
+            answer_any and answer_all,
+            source_url_match,
+            date_pass,
+            not hallu,
+        ]),
+    }
+
+
+def evaluate_schedule_case(case: dict, top_k: int) -> dict:
+    from LLM.sub_model.schedule_index import schedule_search
+
+    query = case.get("query", "")
+    started = time.perf_counter()
+    answer = schedule_search(query, top_k=top_k) or ""
+    latency_ms = round((time.perf_counter() - started) * 1000, 2)
+
+    answer_any = contains_any(answer, case.get("answer_must_contain_any", []))
+    answer_all = contains_all(answer, case.get("answer_must_contain_all", []))
+    date_pass = bool(DATE_RE.search(answer)) if case.get("requires_date", False) else True
+
+    return {
+        "id": case.get("id"),
+        "category": case.get("category", ""),
+        "kind": "schedule",
+        "query": query,
+        "top1_url_match": None,
+        "top3_url_match": None,
+        "top1_title_match": None,
+        "answer_keyword_match": answer_any and answer_all,
+        "source_url_match": True,
+        "date_match": date_pass,
+        "hallucination_detected": False,
+        "hallucination_flags": [],
+        "expected_url_rank": None,
+        "top1_title": "",
+        "top1_url": "",
+        "answer": answer,
+        "retrieval_latency_ms": latency_ms,
+        "answer_latency_ms": 0.0,
+        "passed": all([answer_any and answer_all, date_pass]),
+    }
+
+
+def pct(numerator: int, denominator: int) -> float:
+    return round((numerator / denominator) * 100, 2) if denominator else 0.0
+
+
+def summarize(results: list[dict]) -> dict:
+    search_results = [r for r in results if r["kind"] == "search"]
+    schedule_results = [r for r in results if r["kind"] == "schedule"]
+    latencies = [float(r.get("retrieval_latency_ms", 0.0)) for r in results]
+    answer_latencies = [float(r.get("answer_latency_ms", 0.0)) for r in search_results]
+
+    summary = {
+        "total": len(results),
+        "passed": sum(1 for r in results if r["passed"]),
+        "failed": sum(1 for r in results if not r["passed"]),
+        "pass_rate": pct(sum(1 for r in results if r["passed"]), len(results)),
+        "search_total": len(search_results),
+        "schedule_total": len(schedule_results),
+        "top1_url_accuracy": pct(sum(1 for r in search_results if r["top1_url_match"]), len(search_results)),
+        "top3_url_accuracy": pct(sum(1 for r in search_results if r["top3_url_match"]), len(search_results)),
+        "top1_title_accuracy": pct(sum(1 for r in search_results if r["top1_title_match"]), len(search_results)),
+        "answer_keyword_pass_rate": pct(sum(1 for r in results if r["answer_keyword_match"]), len(results)),
+        "source_url_pass_rate": pct(sum(1 for r in search_results if r["source_url_match"]), len(search_results)),
+        "date_pass_rate": pct(sum(1 for r in results if r["date_match"]), len(results)),
+        "hallucination_proxy_rate": pct(
+            sum(1 for r in search_results if r["hallucination_detected"]),
+            len(search_results),
+        ),
+        "avg_retrieval_latency_ms": round(statistics.mean(latencies), 2) if latencies else 0.0,
+        "p95_retrieval_latency_ms": round(statistics.quantiles(latencies, n=20)[18], 2) if len(latencies) >= 20 else 0.0,
+        "avg_answer_latency_ms": round(statistics.mean(answer_latencies), 2) if answer_latencies else 0.0,
+    }
+
+    by_category = {}
+    for category in sorted({r["category"] for r in results}):
+        items = [r for r in results if r["category"] == category]
+        searches = [r for r in items if r["kind"] == "search"]
+        by_category[category] = {
+            "total": len(items),
+            "pass_rate": pct(sum(1 for r in items if r["passed"]), len(items)),
+            "top3_url_accuracy": pct(sum(1 for r in searches if r["top3_url_match"]), len(searches)),
+            "answer_keyword_pass_rate": pct(sum(1 for r in items if r["answer_keyword_match"]), len(items)),
+        }
+    summary["by_category"] = by_category
+    return summary
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Evaluate RAG retrieval and source-grounded answer quality")
+    ap.add_argument(
+        "--cases",
+        default=str(Path(__file__).with_name("rag_eval_cases.json")),
+        help="path to RAG eval cases JSON",
+    )
+    ap.add_argument("--top-k", type=int, default=5, help="hybrid_search top_k for retrieval metrics")
+    ap.add_argument("--answer-top-k", type=int, default=6, help="build_answer top_k for answer metrics")
+    ap.add_argument("--schedule-top-k", type=int, default=5, help="schedule_search top_k for schedule cases")
+    ap.add_argument("--out", default="/tmp/rag_eval_report.json", help="output report path")
+    ap.add_argument("--fail-on-fail", action="store_true", help="exit 2 when any case fails")
+    args = ap.parse_args()
+
+    cases = load_cases(Path(args.cases))
+    results = []
+    for case in cases:
+        kind = case.get("kind", "search")
+        if kind == "schedule":
+            results.append(evaluate_schedule_case(case, args.schedule_top_k))
+        elif kind == "search":
+            results.append(evaluate_search_case(case, args.top_k, args.answer_top_k))
+        else:
+            raise ValueError(f"unknown case kind: {kind}")
+
+    report = {
+        "cases_file": str(Path(args.cases)),
+        "summary": summarize(results),
+        "results": results,
+    }
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    print(json.dumps(report["summary"], ensure_ascii=False))
+    print(f"report={out_path}")
+
+    failed = [r for r in results if not r["passed"]]
+    if failed:
+        print("failed_cases:")
+        for r in failed:
+            reasons = []
+            if r["top3_url_match"] is False:
+                reasons.append("top3_url")
+            if not r["answer_keyword_match"]:
+                reasons.append("answer_keyword")
+            if not r["source_url_match"]:
+                reasons.append("source_url")
+            if not r["date_match"]:
+                reasons.append("date")
+            if r["hallucination_detected"]:
+                reasons.append("hallucination_proxy")
+            print(f"- {r['id']}: {', '.join(reasons) or 'failed'}")
+
+    return 2 if failed and args.fail_on_fail else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/regression/rag_eval_cases.json
+++ b/tests/regression/rag_eval_cases.json
@@ -1,0 +1,292 @@
+[
+  {
+    "id": "contact_student_success_phone",
+    "category": "contact",
+    "kind": "search",
+    "query": "학생성공지원팀 전화번호 알려줘",
+    "expected_url_contains": ["4377/subview.do"],
+    "expected_title_contains": ["학생성공지원팀"],
+    "answer_must_contain_any": ["02-", "전화", "연락처"],
+    "requires_source_url": true
+  },
+  {
+    "id": "contact_design_pr_center_phone",
+    "category": "contact",
+    "kind": "search",
+    "query": "디자인홍보센터 전화번호",
+    "expected_url_contains": ["4386/subview.do"],
+    "expected_title_contains": ["디자인홍보센터"],
+    "answer_must_contain_any": ["02-2610-5247", "전화", "연락처"],
+    "requires_source_url": true
+  },
+  {
+    "id": "contact_finance_team_phone",
+    "category": "contact",
+    "kind": "search",
+    "query": "재무팀 연락처",
+    "expected_url_contains": ["4381/subview.do"],
+    "expected_title_contains": ["재무팀"],
+    "answer_must_contain_any": ["전화", "연락처", "02-"],
+    "requires_source_url": true
+  },
+  {
+    "id": "contact_education_support_phone",
+    "category": "contact",
+    "kind": "search",
+    "query": "교육지원팀 담당자 전화번호",
+    "expected_url_contains": ["4365/subview.do"],
+    "expected_title_contains": ["교육지원팀"],
+    "answer_must_contain_any": ["전화", "연락처", "02-"],
+    "requires_source_url": true
+  },
+  {
+    "id": "contact_computer_engineering_phone",
+    "category": "contact",
+    "kind": "search",
+    "query": "컴퓨터공학부 연락처",
+    "expected_url_contains": ["4560/subview.do"],
+    "expected_title_contains": ["컴퓨터공학부"],
+    "answer_must_contain_any": ["02-2610-1842", "전화", "연락처"],
+    "requires_source_url": true
+  },
+  {
+    "id": "contact_software_department_phone",
+    "category": "contact",
+    "kind": "search",
+    "query": "컴퓨터소프트웨어공학과 전화번호",
+    "expected_url_contains": ["4560/subview.do", "4573/subview.do"],
+    "expected_title_contains": ["컴퓨터소프트웨어공학과", "컴퓨터공학부"],
+    "answer_must_contain_any": ["02-2610-1843", "전화", "연락처"],
+    "requires_source_url": true
+  },
+  {
+    "id": "policy_leave_absence",
+    "category": "policy",
+    "kind": "search",
+    "query": "휴학 신청 안내",
+    "expected_url_contains": ["4784/subview.do"],
+    "expected_title_contains": ["휴학"],
+    "answer_must_contain_any": ["휴학", "4784/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "policy_return_to_school",
+    "category": "policy",
+    "kind": "search",
+    "query": "복학 안내",
+    "expected_url_contains": ["4785/subview.do"],
+    "expected_title_contains": ["복학"],
+    "answer_must_contain_any": ["복학", "4785/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "policy_course_registration",
+    "category": "policy",
+    "kind": "search",
+    "query": "수강신청 안내",
+    "expected_url_contains": ["4752/subview.do", "4753/subview.do"],
+    "expected_title_contains": ["수강신청"],
+    "answer_must_contain_any": ["수강신청", "4752/subview.do", "4753/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "policy_registration_tuition",
+    "category": "policy",
+    "kind": "search",
+    "query": "등록금납부 안내",
+    "expected_url_contains": ["4793/subview.do"],
+    "expected_title_contains": ["등록금납부"],
+    "answer_must_contain_any": ["등록금", "4793/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "policy_internal_external_scholarship",
+    "category": "policy",
+    "kind": "search",
+    "query": "교내외장학금 안내",
+    "expected_url_contains": ["4794/subview.do"],
+    "expected_title_contains": ["교내외장학금"],
+    "answer_must_contain_any": ["장학", "4794/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "policy_national_scholarship",
+    "category": "policy",
+    "kind": "search",
+    "query": "국가장학금 안내",
+    "expected_url_contains": ["4795/subview.do"],
+    "expected_title_contains": ["국가장학금"],
+    "answer_must_contain_any": ["국가장학금", "4795/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "policy_student_loan",
+    "category": "policy",
+    "kind": "search",
+    "query": "학자금대출 안내",
+    "expected_url_contains": ["4796/subview.do"],
+    "expected_title_contains": ["학자금대출"],
+    "answer_must_contain_any": ["학자금", "4796/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "policy_certificate_issue",
+    "category": "policy",
+    "kind": "search",
+    "query": "제증명서발급 안내",
+    "expected_url_contains": ["4799/subview.do"],
+    "expected_title_contains": ["제증명서발급", "인터넷에의한발급"],
+    "answer_must_contain_any": ["증명서", "4799/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "policy_field_training",
+    "category": "policy",
+    "kind": "search",
+    "query": "현장실습 안내",
+    "expected_url_contains": ["4756/subview.do"],
+    "expected_title_contains": ["현장실습"],
+    "answer_must_contain_any": ["현장실습", "4756/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "grad_professional_associate",
+    "category": "grad",
+    "kind": "search",
+    "query": "전문학사 졸업학점 알려줘",
+    "expected_url_contains": ["4778/subview.do"],
+    "expected_title_contains": ["전문학사"],
+    "answer_must_contain_any": ["졸업", "학점"],
+    "requires_source_url": true
+  },
+  {
+    "id": "grad_postponement",
+    "category": "grad",
+    "kind": "search",
+    "query": "졸업보류 안내",
+    "expected_url_contains": ["4781/subview.do"],
+    "expected_title_contains": ["졸업보류"],
+    "answer_must_contain_any": ["졸업보류", "4781/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "grad_deferment",
+    "category": "grad",
+    "kind": "search",
+    "query": "졸업유예 안내",
+    "expected_url_contains": ["4782/subview.do"],
+    "expected_title_contains": ["졸업유예"],
+    "answer_must_contain_any": ["졸업유예", "4782/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "department_computer_engineering_intro",
+    "category": "department",
+    "kind": "search",
+    "query": "컴퓨터공학부 소개",
+    "expected_url_contains": ["4560/subview.do"],
+    "expected_title_contains": ["컴퓨터공학부"],
+    "answer_must_contain_any": ["컴퓨터공학부", "4560/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "department_software_intro",
+    "category": "department",
+    "kind": "search",
+    "query": "컴퓨터소프트웨어공학과 소개",
+    "expected_url_contains": ["4573/subview.do", "4560/subview.do"],
+    "expected_title_contains": ["컴퓨터소프트웨어공학과", "컴퓨터공학부"],
+    "answer_must_contain_any": ["컴퓨터소프트웨어공학과", "소프트웨어", "4573/subview.do", "4560/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "department_business_intro",
+    "category": "department",
+    "kind": "search",
+    "query": "경영학과 소개",
+    "expected_url_contains": ["4670/subview.do"],
+    "expected_title_contains": ["경영학과"],
+    "answer_must_contain_any": ["경영학과", "4658/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "department_visual_design_intro",
+    "category": "department",
+    "kind": "search",
+    "query": "시각디자인과 소개",
+    "expected_url_contains": ["4647/subview.do"],
+    "expected_title_contains": ["시각디자인과"],
+    "answer_must_contain_any": ["시각디자인과", "4649/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "life_dorm_entry",
+    "category": "dorm",
+    "kind": "search",
+    "query": "기숙사 입사 안내",
+    "expected_url_contains": ["4843/subview.do"],
+    "expected_title_contains": ["입사 안내"],
+    "answer_must_contain_any": ["입사", "4843/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "life_dorm_rules",
+    "category": "dorm",
+    "kind": "search",
+    "query": "기숙사 생활수칙",
+    "expected_url_contains": ["4845/subview.do"],
+    "expected_title_contains": ["생활수칙"],
+    "answer_must_contain_any": ["생활수칙", "4845/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "privacy_policy",
+    "category": "privacy",
+    "kind": "search",
+    "query": "개인정보처리방침",
+    "expected_url_contains": ["4924/subview.do"],
+    "expected_title_contains": ["개인정보처리방침"],
+    "answer_must_contain_any": ["개인정보", "4924/subview.do"],
+    "requires_source_url": true
+  },
+  {
+    "id": "schedule_commencement_2025",
+    "category": "schedule",
+    "kind": "schedule",
+    "query": "2025년 학위수여식 알려줘",
+    "answer_must_contain_any": ["2025-02-21", "학위수여식"],
+    "requires_date": true
+  },
+  {
+    "id": "schedule_semester_start_2025",
+    "category": "schedule",
+    "kind": "schedule",
+    "query": "2025년 1학기 개강일",
+    "answer_must_contain_any": ["2025-03-04", "개강"],
+    "requires_date": true
+  },
+  {
+    "id": "schedule_midterm_2025",
+    "category": "schedule",
+    "kind": "schedule",
+    "query": "2025년 중간고사 일정",
+    "answer_must_contain_any": ["2025", "중간고사"],
+    "requires_date": true
+  },
+  {
+    "id": "schedule_final_2025",
+    "category": "schedule",
+    "kind": "schedule",
+    "query": "2025년 기말고사 일정",
+    "answer_must_contain_any": ["2025", "학기말고사", "기말고사"],
+    "requires_date": true
+  },
+  {
+    "id": "schedule_course_change_2025",
+    "category": "schedule",
+    "kind": "schedule",
+    "query": "2025년 수강신청 정정기간",
+    "answer_must_contain_any": ["2025", "수강신청", "정정"],
+    "requires_date": true
+  }
+]


### PR DESCRIPTION
## 관련 이슈

Open #109 

## 🎯 배경

- 챗봇 RAG 성능 개선을 위해 검색 품질을 정량적으로 확인할 수 있는 평가 기준이 필요했습니다.
- 기존에는 개별 회귀 테스트 중심이라 Top-1/Top-3 검색 정확도, 출처 URL 일치 여부, 날짜 포함 여부, 응답 시간 등을 한 번에 보기 어려웠습니다.
- 평가 과정에서 `복학`, `현장실습`, `졸업보류`, `졸업유예`, `전문학사 졸업학점`처럼 검색 후보는 잡히지만 최종 답변 출처가 어긋나는 케이스가 확인되어, 검색 결과 재정렬 규칙도 함께 보정했습니다.

## 🔍 주요 내용

- RAG 평가 자동화 스크립트 추가
  - `tests/regression/evaluate_rag_retrieval.py`
  - Top-1 URL 정확도, Top-3 URL 정확도, 제목 일치, 답변 키워드 포함, 출처 URL 일치, 날짜 포함, hallucination proxy, 응답 시간 측정

- RAG 평가셋 30개 추가
  - `tests/regression/rag_eval_cases.json`
  - 연락처, 정책, 졸업, 학과 소개, 기숙사, 개인정보처리방침, 학사일정 케이스 포함

- 검색/답변 재정렬 규칙 개선
  - `졸업보류`, `졸업유예`, `졸업연기`는 학점 질문이 아니면 졸업학점 추출 로직을 타지 않도록 분리
  - `title`, `leaf_title`, `breadcrumb`의 핵심 토큰 매칭 점수를 최종 답변 후보 정렬에 반영
  - `현장실습 안내`처럼 부서/센터가 아닌 학사안내 페이지가 우선되어야 하는 정책성 질문 보정
  - `전문학사 졸업학점` 질의에서 전문학사 페이지가 우선되도록 졸업학점 검색 재정렬 보정

- 검증 결과
  - 신규 RAG 평가셋 30개 통과
  - 기존 query index 호환성/메타데이터 품질 회귀 테스트 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 요약
RAG 검색 성능을 평가하기 위한 자동화된 평가 스크립트와 30개의 테스트 케이스를 추가했습니다. 동시에 졸업학점, 정책 검색 등에 대한 답변 재순위 로직을 개선하여 더 정확한 검색 결과를 제공합니다.

## 주요 변경점
- 📊 **평가 스크립트 추가** (`evaluate_rag_retrieval.py`): Top-1/Top-3 URL 정확도, 제목 매칭, 할루시네이션 감지 등 8가지 메트릭으로 RAG 성능 측정
- 📋 **평가 데이터셋** (`rag_eval_cases.json`): 연락처, 정책, 졸업, 학과, 기숙사, 개인정보, 학사일정 등 7개 카테고리의 30개 테스트 케이스
- 🔍 **졸업 관련 쿼리 처리 개선**: "졸업보류", "졸업유예", "졸업연기" 같은 특정 쿼리를 따로 처리하여 불필요한 학점 추출 로직 방지
- ⭐ **답변 재순위 로직 확장**: 제목, 하위 제목, 브레드크럼 정보를 활용한 추가 매칭 스코어로 답변 순위 개선
- 📚 **학과 정보 우선순위 조정**: 정책 관련 질문에 학술 지도 페이지를 학과/센터 페이지보다 우선 배치
- 🎓 **전문학사 졸업학점 최적화**: "전문학사 졸업학점" 쿼리에 특화된 페이지를 선호하도록 부스트

## 주의/리스크
- 🔧 재순위 로직이 복잡해지면서 예상치 못한 쿼리에서 순위 변동 가능성 — 모니터링 필요
- 💾 30개 테스트 케이스는 기본값이므로 실제 사용자 쿼리로 추가 검증 권장

## 다음 액션
- ✅ 프로덕션 배포 후 평가 스크립트를 CI/CD 파이프라인에 통합하여 지속적 모니터링
- 📊 실제 사용자 쿼리로 더 많은 케이스를 수집하여 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->