### PR TITLE
refactor: introduce chatbot tool routing abstraction

### DIFF
--- a/.github/workflows/rag-light-check.yml
+++ b/.github/workflows/rag-light-check.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/LLM/OSS/service.py
+++ b/LLM/OSS/service.py
@@ -19,8 +19,6 @@ from core.exceptions import ConfigurationError
 from core.logging import get_logger
 from core.settings import get_settings
 from LLM.OSS.formatter import (
-    dept_clarification_message,
-    render_chatty_schedule,
     scrub_non_contact,
 )
 from LLM.OSS.modes import (
@@ -33,10 +31,13 @@ from LLM.OSS.modes import (
     looks_like_schedule,
     looks_like_topic,
 )
-from LLM.OSS.postprocess import run_postprocess
+from LLM.OSS.tools import (
+    run_empty_oss_fallback_tools,
+    run_final_fallback_tools,
+    run_mode_tools,
+    run_oss_fast_path_tools,
+)
 from LLM.rule_book.graph import run_rule_book
-from LLM.sub_model.query_index import build_answer, confident_search_answer, metadata_direct_answer
-from LLM.sub_model.schedule_index import schedule_search
 
 
 settings = get_settings()
@@ -249,27 +250,6 @@ async def should_block_profanity(user_text: str) -> bool:
     return any(str(label).strip() == "비속어" for label in results)
 
 
-def call_submodel(user_text: str) -> str:
-    base = ""
-    try:
-        result = build_answer(user_text, top_k=12)
-        base = (result or {}).get("answer", "").strip()
-    except Exception:
-        base = ""
-
-    if settings.json_only_mode:
-        return base
-
-    try:
-        schedule = schedule_search(user_text, top_k=8)
-    except Exception:
-        schedule = ""
-
-    if schedule and base:
-        return schedule + "\n" + base
-    return schedule or base
-
-
 def extract_user_text(req: ChatReq) -> str:
     if req.text:
         return req.text.strip()
@@ -347,159 +327,54 @@ async def chat_with_oss(req: ChatReq) -> dict:
             "text": f"우리는 {settings.org_name} 정보를 함께 해결하는 대화 파트너이고, 저는 {settings.service_name}의 {settings.bot_name}입니다.",
         }
 
-    if mode == "fast":
-        if any(keyword in user_text for keyword in ("종강", "졸업식", "종업식", "학위수여식")):
-            schedule_only = schedule_search(user_text, top_k=8)
-            if schedule_only:
-                return cache_and_return({"engine": "fast", "text": render_chatty_schedule(schedule_only, user_text)})
-
-        direct = metadata_direct_answer(user_text)
-        if direct:
-            response = {"engine": "fast", "text": direct["answer"]}
-            if direct.get("url"):
-                response["url"] = direct["url"]
-            return cache_and_return(response)
-
-        schedule_only = schedule_search(user_text, top_k=8)
-        if schedule_only:
-            return cache_and_return({"engine": "fast", "text": render_chatty_schedule(schedule_only, user_text)})
-
-        clarification = dept_clarification_message(user_text)
-        if clarification:
-            return cache_and_return({"engine": "fast", "text": clarification})
-
-        sub_answer = call_submodel(user_text)
-        text, url = run_postprocess("fast", user_text, sub_answer)
-        response = {"engine": "fast", "text": text}
-        if url:
-            response["url"] = url
-        return cache_and_return(response)
-
-    if mode == "policy":
-        direct = metadata_direct_answer(user_text)
-        if direct:
-            response = {"engine": "policy", "text": direct["answer"]}
-            if direct.get("url"):
-                response["url"] = direct["url"]
-            return cache_and_return(response)
-
-        sub_answer = call_submodel(user_text)
-        text, url = run_postprocess("policy", user_text, sub_answer)
-        response = {"engine": "policy", "text": text}
-        if url:
-            response["url"] = url
-        return cache_and_return(response)
-
-    if mode == "dorm":
-        sub_answer = call_submodel(user_text)
-        text, url = run_postprocess("dorm", user_text, sub_answer)
-        response = {"engine": "dorm", "text": text}
-        if url:
-            response["url"] = url
-        return cache_and_return(response)
-
-    if mode == "grad":
-        direct = metadata_direct_answer(user_text)
-        if direct:
-            response = {"engine": "grad", "text": direct["answer"]}
-            if direct.get("url"):
-                response["url"] = direct["url"]
-            return cache_and_return(response)
-
-        sub_answer = call_submodel(user_text)
-        text, url = run_postprocess("grad", user_text, sub_answer)
-        response = {"engine": "grad", "text": text}
-        if url:
-            response["url"] = url
-        return cache_and_return(response)
-
-    if mode == "topic":
-        sub_answer = call_submodel(user_text)
-        text, url = run_postprocess("topic", user_text, sub_answer)
-        response = {"engine": "topic", "text": text}
-        if url:
-            response["url"] = url
-        return cache_and_return(response)
+    tool_result = run_mode_tools(mode, user_text)
+    if tool_result.handled:
+        return cache_and_return(tool_result.to_response())
 
     if mode == "oss":
-        direct = metadata_direct_answer(user_text)
-        if direct:
-            response = {"engine": "fast", "text": direct["answer"]}
-            if direct.get("url"):
-                response["url"] = direct["url"]
-            return cache_and_return(response)
-
-        confident = confident_search_answer(user_text, top_k=2)
-        if confident:
-            response = {"engine": "fast", "text": confident["answer"]}
-            if confident.get("url"):
-                response["url"] = confident["url"]
-            return cache_and_return(response)
+        fast_path = run_oss_fast_path_tools(user_text)
+        if fast_path.resolved:
+            return cache_and_return(fast_path.to_response())
 
         output = await call_oss_async(messages_for_oss)
         if not any(keyword in user_text for keyword in ("연락처", "전화", "번호", "문의")) and not any(keyword in user_text for keyword in COUNCIL_KWS):
             output = scrub_non_contact(output)
 
         if not output:
-            if looks_like_schedule(user_text):
-                schedule_only = schedule_search(user_text, top_k=8)
-                if schedule_only:
-                    response = {"engine": "fast", "text": render_chatty_schedule(schedule_only, user_text)}
-                    latency = int((time.monotonic() - start) * 1000)
-                    _log_executor.submit(_log_chatbot, user_text, "fast", response["text"], None, False, latency)
-                    return response
+            fallback = run_empty_oss_fallback_tools(user_text)
+            if fallback.handled:
+                response = fallback.to_response()
+                latency = int((time.monotonic() - start) * 1000)
+                _log_executor.submit(_log_chatbot, user_text, response["engine"], response["text"], response.get("url"), False, latency)
+                return response
 
             if len(user_text) <= 2 or GREETING_RE.search(user_text):
                 output = "안녕하세요, 무엇을 도와드릴까요?"
             else:
-                sub_answer = call_submodel(user_text)
-                if looks_like_schedule(user_text) and sub_answer:
-                    response = {"engine": "fast", "text": render_chatty_schedule(sub_answer, user_text)}
-                    latency = int((time.monotonic() - start) * 1000)
-                    _log_executor.submit(_log_chatbot, user_text, "fast", response["text"], None, False, latency)
-                    return response
-                if sub_answer:
-                    if looks_like_topic(user_text):
-                        text, _ = run_postprocess("topic", user_text, sub_answer)
-                    else:
-                        text, _ = run_postprocess("fast", user_text, sub_answer)
-                    output = text
-                else:
-                    output = "잘 이해하지 못했어요. 다시 질문해주세요."
+                output = "잘 이해하지 못했어요. 다시 질문해주세요."
 
         latency = int((time.monotonic() - start) * 1000)
         _log_executor.submit(_log_chatbot, user_text, "oss", output, None, False, latency)
         return {"engine": "oss", "text": output}
 
-    direct = metadata_direct_answer(user_text)
-    if direct:
-        response = {"engine": "fast", "text": direct["answer"]}
-        if direct.get("url"):
-            response["url"] = direct["url"]
-        return cache_and_return(response)
+    fallback = run_final_fallback_tools(mode, user_text)
+    if fallback.resolved:
+        return cache_and_return(fallback.to_response())
 
-    confident = confident_search_answer(user_text, top_k=2)
-    if confident:
-        response = {"engine": "fast", "text": confident["answer"]}
-        if confident.get("url"):
-            response["url"] = confident["url"]
-        return cache_and_return(response)
-
-    sub_answer = call_submodel(user_text)
     fused = await call_oss_async(
         [
             {
                 "role": "system",
                 "content": "Reasoning: low\n다음 <context>의 사실만 사용해 한국어로 한 문장으로만 답하라. 불릿/개행 금지. 임의의 전화번호/URL을 생성하지 말라.",
             },
-            {"role": "user", "content": user_text + "\n\n<context>\n" + (sub_answer or "") + "\n</context>"},
+            {"role": "user", "content": user_text + "\n\n<context>\n" + (fallback.text or "") + "\n</context>"},
         ],
         max_tokens=96,
         temperature=0.2,
         timeout=45,
     )
     if not fused:
-        text, _ = run_postprocess("topic", user_text, sub_answer)
+        text = run_mode_tools("topic", user_text).text
         fused = text if looks_like_topic(user_text) else "좋아요, 무엇을 이야기해 볼까요?"
 
     latency = int((time.monotonic() - start) * 1000)

--- a/LLM/OSS/service.py
+++ b/LLM/OSS/service.py
@@ -328,7 +328,7 @@ async def chat_with_oss(req: ChatReq) -> dict:
         }
 
     tool_result = run_mode_tools(mode, user_text)
-    if tool_result.handled:
+    if tool_result.resolved:
         return cache_and_return(tool_result.to_response())
 
     if mode == "oss":
@@ -350,12 +350,11 @@ async def chat_with_oss(req: ChatReq) -> dict:
 
             if len(user_text) <= 2 or GREETING_RE.search(user_text):
                 output = "안녕하세요, 무엇을 도와드릴까요?"
-            else:
-                output = "잘 이해하지 못했어요. 다시 질문해주세요."
 
-        latency = int((time.monotonic() - start) * 1000)
-        _log_executor.submit(_log_chatbot, user_text, "oss", output, None, False, latency)
-        return {"engine": "oss", "text": output}
+        if output:
+            latency = int((time.monotonic() - start) * 1000)
+            _log_executor.submit(_log_chatbot, user_text, "oss", output, None, False, latency)
+            return {"engine": "oss", "text": output}
 
     fallback = run_final_fallback_tools(mode, user_text)
     if fallback.resolved:

--- a/LLM/OSS/tools.py
+++ b/LLM/OSS/tools.py
@@ -1,0 +1,207 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from core.settings import get_settings
+from LLM.OSS.formatter import (
+    dept_clarification_message,
+    render_chatty_schedule,
+)
+from LLM.OSS.modes import looks_like_schedule, looks_like_topic
+from LLM.OSS.postprocess import run_postprocess
+from LLM.sub_model.query_index import build_answer, confident_search_answer, metadata_direct_answer
+from LLM.sub_model.schedule_index import schedule_search
+
+
+settings = get_settings()
+
+
+@dataclass(frozen=True)
+class ToolResult:
+    name: str
+    text: str = ""
+    url: Optional[str] = None
+    engine: str = "fast"
+    confidence: float = 0.0
+    llm_required: bool = False
+
+    @property
+    def resolved(self) -> bool:
+        return bool(self.text.strip()) and not self.llm_required
+
+    @property
+    def handled(self) -> bool:
+        return self.name != "none" and not self.llm_required
+
+    def to_response(self) -> dict:
+        response = {"engine": self.engine, "text": self.text}
+        if self.url:
+            response["url"] = self.url
+        return response
+
+
+EMPTY_TOOL_RESULT = ToolResult(name="none", confidence=0.0)
+
+
+def call_submodel(user_text: str) -> str:
+    base = ""
+    try:
+        result = build_answer(user_text, top_k=12)
+        base = (result or {}).get("answer", "").strip()
+    except Exception:
+        base = ""
+
+    if settings.json_only_mode:
+        return base
+
+    try:
+        schedule = schedule_search(user_text, top_k=8)
+    except Exception:
+        schedule = ""
+
+    if schedule and base:
+        return schedule + "\n" + base
+    return schedule or base
+
+
+def _direct_answer_tool(user_text: str, engine: str) -> ToolResult:
+    direct = metadata_direct_answer(user_text)
+    if not direct:
+        return EMPTY_TOOL_RESULT
+    return ToolResult(
+        name="metadata_direct_answer",
+        text=direct["answer"],
+        url=direct.get("url"),
+        engine=engine,
+        confidence=0.95,
+    )
+
+
+def _schedule_tool(user_text: str, *, ceremonial_first: bool = False) -> ToolResult:
+    if ceremonial_first and not any(keyword in user_text for keyword in ("종강", "졸업식", "종업식", "학위수여식")):
+        return EMPTY_TOOL_RESULT
+
+    schedule = schedule_search(user_text, top_k=8)
+    if not schedule:
+        return EMPTY_TOOL_RESULT
+    return ToolResult(
+        name="schedule_search",
+        text=render_chatty_schedule(schedule, user_text),
+        engine="fast",
+        confidence=0.9,
+    )
+
+
+def _clarification_tool(user_text: str) -> ToolResult:
+    clarification = dept_clarification_message(user_text)
+    if not clarification:
+        return EMPTY_TOOL_RESULT
+    return ToolResult(
+        name="dept_clarification",
+        text=clarification,
+        engine="fast",
+        confidence=0.85,
+    )
+
+
+def _postprocess_tool(mode: str, user_text: str) -> ToolResult:
+    sub_answer = call_submodel(user_text)
+    text, url = run_postprocess(mode, user_text, sub_answer)
+    return ToolResult(
+        name=f"{mode}_search_postprocess",
+        text=text,
+        url=url,
+        engine=mode,
+        confidence=0.65 if text else 0.0,
+    )
+
+
+def _confident_search_tool(user_text: str) -> ToolResult:
+    confident = confident_search_answer(user_text, top_k=2)
+    if not confident:
+        return EMPTY_TOOL_RESULT
+    return ToolResult(
+        name="confident_search_answer",
+        text=confident["answer"],
+        url=confident.get("url"),
+        engine="fast",
+        confidence=0.85,
+    )
+
+
+def run_mode_tools(mode: str, user_text: str) -> ToolResult:
+    if mode == "fast":
+        for tool in (
+            lambda: _schedule_tool(user_text, ceremonial_first=True),
+            lambda: _direct_answer_tool(user_text, "fast"),
+            lambda: _schedule_tool(user_text),
+            lambda: _clarification_tool(user_text),
+        ):
+            tool_result = tool()
+            if tool_result.resolved:
+                return tool_result
+        return _postprocess_tool("fast", user_text)
+
+    if mode in {"policy", "grad"}:
+        direct = _direct_answer_tool(user_text, mode)
+        if direct.resolved:
+            return direct
+        return _postprocess_tool(mode, user_text)
+
+    if mode in {"dorm", "topic"}:
+        return _postprocess_tool(mode, user_text)
+
+    return EMPTY_TOOL_RESULT
+
+
+def run_oss_fast_path_tools(user_text: str) -> ToolResult:
+    for tool in (
+        lambda: _direct_answer_tool(user_text, "fast"),
+        lambda: _confident_search_tool(user_text),
+    ):
+        tool_result = tool()
+        if tool_result.resolved:
+            return tool_result
+    return EMPTY_TOOL_RESULT
+
+
+def run_empty_oss_fallback_tools(user_text: str) -> ToolResult:
+    if looks_like_schedule(user_text):
+        schedule = _schedule_tool(user_text)
+        if schedule.resolved:
+            return schedule
+
+    sub_answer = call_submodel(user_text)
+    if looks_like_schedule(user_text) and sub_answer:
+        return ToolResult(
+            name="schedule_submodel_fallback",
+            text=render_chatty_schedule(sub_answer, user_text),
+            engine="fast",
+            confidence=0.7,
+        )
+    if sub_answer:
+        mode = "topic" if looks_like_topic(user_text) else "fast"
+        text, _ = run_postprocess(mode, user_text, sub_answer)
+        return ToolResult(
+            name=f"{mode}_oss_empty_fallback",
+            text=text,
+            engine="oss",
+            confidence=0.6 if text else 0.0,
+        )
+    return EMPTY_TOOL_RESULT
+
+
+def run_final_fallback_tools(mode: str, user_text: str) -> ToolResult:
+    for tool in (
+        lambda: _direct_answer_tool(user_text, "fast"),
+        lambda: _confident_search_tool(user_text),
+    ):
+        tool_result = tool()
+        if tool_result.resolved:
+            return tool_result
+    return ToolResult(
+        name="rag_context_required",
+        text=call_submodel(user_text),
+        engine=mode,
+        confidence=0.5,
+        llm_required=True,
+    )

--- a/LLM/OSS/tools.py
+++ b/LLM/OSS/tools.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Optional
+import logging
 
 from core.settings import get_settings
 from LLM.OSS.formatter import (
@@ -13,6 +14,7 @@ from LLM.sub_model.schedule_index import schedule_search
 
 
 settings = get_settings()
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -47,7 +49,8 @@ def call_submodel(user_text: str) -> str:
     try:
         result = build_answer(user_text, top_k=12)
         base = (result or {}).get("answer", "").strip()
-    except Exception:
+    except Exception as exc:
+        logger.warning("build_answer failed: %s", exc, exc_info=True)
         base = ""
 
     if settings.json_only_mode:
@@ -55,7 +58,8 @@ def call_submodel(user_text: str) -> str:
 
     try:
         schedule = schedule_search(user_text, top_k=8)
-    except Exception:
+    except Exception as exc:
+        logger.warning("schedule_search failed: %s", exc, exc_info=True)
         schedule = ""
 
     if schedule and base:
@@ -64,7 +68,10 @@ def call_submodel(user_text: str) -> str:
 
 
 def _direct_answer_tool(user_text: str, engine: str) -> ToolResult:
-    direct = metadata_direct_answer(user_text)
+    try:
+        direct = metadata_direct_answer(user_text)
+    except Exception:
+        return EMPTY_TOOL_RESULT
     if not direct:
         return EMPTY_TOOL_RESULT
     return ToolResult(
@@ -80,7 +87,10 @@ def _schedule_tool(user_text: str, *, ceremonial_first: bool = False) -> ToolRes
     if ceremonial_first and not any(keyword in user_text for keyword in ("종강", "졸업식", "종업식", "학위수여식")):
         return EMPTY_TOOL_RESULT
 
-    schedule = schedule_search(user_text, top_k=8)
+    try:
+        schedule = schedule_search(user_text, top_k=8)
+    except Exception:
+        return EMPTY_TOOL_RESULT
     if not schedule:
         return EMPTY_TOOL_RESULT
     return ToolResult(
@@ -92,7 +102,10 @@ def _schedule_tool(user_text: str, *, ceremonial_first: bool = False) -> ToolRes
 
 
 def _clarification_tool(user_text: str) -> ToolResult:
-    clarification = dept_clarification_message(user_text)
+    try:
+        clarification = dept_clarification_message(user_text)
+    except Exception:
+        return EMPTY_TOOL_RESULT
     if not clarification:
         return EMPTY_TOOL_RESULT
     return ToolResult(
@@ -104,8 +117,11 @@ def _clarification_tool(user_text: str) -> ToolResult:
 
 
 def _postprocess_tool(mode: str, user_text: str) -> ToolResult:
-    sub_answer = call_submodel(user_text)
-    text, url = run_postprocess(mode, user_text, sub_answer)
+    try:
+        sub_answer = call_submodel(user_text)
+        text, url = run_postprocess(mode, user_text, sub_answer)
+    except Exception:
+        return EMPTY_TOOL_RESULT
     return ToolResult(
         name=f"{mode}_search_postprocess",
         text=text,
@@ -116,7 +132,10 @@ def _postprocess_tool(mode: str, user_text: str) -> ToolResult:
 
 
 def _confident_search_tool(user_text: str) -> ToolResult:
-    confident = confident_search_answer(user_text, top_k=2)
+    try:
+        confident = confident_search_answer(user_text, top_k=2)
+    except Exception:
+        return EMPTY_TOOL_RESULT
     if not confident:
         return EMPTY_TOOL_RESULT
     return ToolResult(
@@ -180,10 +199,11 @@ def run_empty_oss_fallback_tools(user_text: str) -> ToolResult:
         )
     if sub_answer:
         mode = "topic" if looks_like_topic(user_text) else "fast"
-        text, _ = run_postprocess(mode, user_text, sub_answer)
+        text, url = run_postprocess(mode, user_text, sub_answer)
         return ToolResult(
             name=f"{mode}_oss_empty_fallback",
             text=text,
+            url=url,
             engine="oss",
             confidence=0.6 if text else 0.0,
         )

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -73,6 +73,7 @@
 │   ├── OSS/
 │   │   ├── Open_AI_OSS.py          # 챗봇 메인 오케스트레이션
 │   │   ├── service.py              # 챗봇 서비스 연결부
+│   │   ├── tools.py                # 비용 우선 deterministic tool routing
 │   │   ├── formatter.py            # 응답 포맷팅
 │   │   ├── modes.py                # 챗봇 모드 정의
 │   │   └── postprocess/
@@ -147,6 +148,7 @@
 
 - `LLM/OSS/Open_AI_OSS.py`
 - `LLM/OSS/service.py`
+- `LLM/OSS/tools.py`
 - `LLM/OSS/formatter.py`
 - `LLM/OSS/modes.py`
 


### PR DESCRIPTION
## 관련 이슈

Open #118 

## 🎯 배경

- 챗봇 서비스의 mode별 분기와 검색/후처리 호출이 `service.py`에 집중되어 있어, 비용 우선 tool routing 구조를 명확히 드러내기 어려웠습니다.
- 실서비스 제약을 유지하면서 LLM 호출 전에 deterministic tool을 우선 실행하는 구조를 분리할 필요가 있었습니다.

## 🔍 주요 내용

- `LLM/OSS/tools.py`를 추가해 `ToolResult`와 deterministic chatbot tool routing helper를 분리했습니다.
- `service.py`의 `fast/policy/dorm/grad/topic/oss` 반복 분기를 `run_mode_tools()`, `run_oss_fast_path_tools()` 중심으로 정리했습니다.
- 기존 검색, 일정, metadata direct answer, postprocess 로직은 재사용해 기능 변경 범위를 최소화했습니다.
- `docs/PLANS.md`에 새 챗봇 tool routing 모듈을 반영했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 요약
챗봇의 도구 라우팅 로직을 추상화하여 `service.py`의 복잡한 모드별 분기를 체계적으로 정리했습니다. 새로운 `tools.py` 모듈에서 `ToolResult` 기반 결정적 도구 실행 흐름을 구성하고, `service.py`는 이를 활용해 더 간결하게 리팩토링했습니다.

## 주요 변경점
- **ToolResult 데이터클래스 추가**: 모든 도구의 결과를 표준화하여 `name`, `text`, `engine`, `confidence`, `llm_required` 등을 관리
- **모드별 도구 실행 함수**: `run_mode_tools()`, `run_oss_fast_path_tools()`, `run_empty_oss_fallback_tools()`, `run_final_fallback_tools()` 추가로 단계별 라우팅 구현
- **개별 도구 헬퍼**: 메타데이터 직접 답변, 스케줄 검색, 학과 명확화, 후처리, 자신감 기반 답변 등을 독립적인 함수로 분리
- **service.py 간소화**: 흩어진 `fast/policy/dorm/grad/topic/oss` 분기를 도구 함수로 통합해 `chat_with_oss()` 가독성 개선
- **폴백 전략 체계화**: OSS 출력 비어있을 때와 최종 폴백 처리를 명확한 단계로 구분
- **기존 로직 재사용**: 검색, 캘린더, 메타데이터, 후처리 로직을 기존 함수로 유지하여 기능 변화 최소화
- **문서 업데이트**: `docs/PLANS.md`에 `tools.py`를 "비용 우선 결정적 도구 라우팅"으로 등록

## 주의/리스크
- **큰 리팩토링으로 인한 회귀 테스트 필수**: 모드별 동작이 분산되었으므로 각 모드(`fast`, `policy`, `dorm`, `grad`, `topic`, `oss`)별 엔드투엔드 테스트 확인 필요
- **도구 우선순위 변경**: 모드에 따라 도구 실행 순서가 변경되었으므로 기존과 동일한 응답이 나오는지 검증 필요
- **OSS 폴백 흐름의 복잡성**: 빈 출력 → 폴백 → 최종 폴백까지 여러 단계를 거치므로, 각 단계의 조건과 반환값을 정확히 추적할 것

## 다음 액션
- 모드별(특히 `oss` 모드) 통합 테스트 실행 및 응답 품질 확인
- 로그에서 도구 실행 단계와 엔진 선택 이유가 명확히 기록되는지 모니터링
- 폴백 조건(연락처/문의/위원회 키워드)이 정상 작동하는지 유즈 케이스로 검증

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dongsooop/AI/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->