### PR TITLE
refactor: organize chatbot rag orchestration

### DIFF
--- a/.github/workflows/rag-light-check.yml
+++ b/.github/workflows/rag-light-check.yml
@@ -32,12 +32,16 @@ jobs:
         run: |
           python -m py_compile \
             tests/regression/evaluate_rag_retrieval.py \
+            tests/regression/check_chatbot_tool_routing.py \
             tests/regression/check_query_index_compat.py \
             tests/regression/check_query_index_metadata_quality.py \
+            LLM/OSS/tools.py \
+            LLM/OSS/service.py \
             LLM/sub_model/query_index.py
 
       - name: Run lightweight query-index compatibility checks
         run: |
+          python tests/regression/check_chatbot_tool_routing.py
           python tests/regression/check_query_index_compat.py
           python tests/regression/check_query_index_metadata_quality.py
 
@@ -49,7 +53,7 @@ jobs:
             echo ""
             echo "- Triggered by: \`${{ github.event_name }}\`"
             echo "- PR label required: \`run-rag-check\`"
-            echo "- Checks: question-set schema validation, Python compile, lightweight query-index regressions"
+            echo "- Checks: question-set schema validation, Python compile, lightweight chatbot routing/query-index regressions"
             echo ""
             echo "This workflow does not run the full local model-backed 30-case RAG evaluation."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ setting.txt
 __pycache__
 .ipynb_checkpoints/
 hs_err_pid*.log
+tests/regression/reports/
 
 # Local dependencies
 requirements.txt

--- a/LLM/OSS/service.py
+++ b/LLM/OSS/service.py
@@ -32,6 +32,7 @@ from LLM.OSS.modes import (
     looks_like_topic,
 )
 from LLM.OSS.tools import (
+    ToolResult,
     run_empty_oss_fallback_tools,
     run_final_fallback_tools,
     run_mode_tools,
@@ -169,6 +170,23 @@ def _log_chatbot(query: str, mode: str, response: str, url: Optional[str], cache
     finally:
         if conn and _db_pool:
             _db_pool.putconn(conn)
+
+
+def _log_tool_route(user_text: str, mode: str, stage: str, result: ToolResult) -> None:
+    query_hash = hashlib.sha256((user_text or "").encode("utf-8")).hexdigest()[:12]
+    logger.info(
+        "chatbot_tool_route query_hash=%s mode=%s stage=%s tool=%s engine=%s confidence=%.2f "
+        "llm_required=%s has_text=%s reason=%s",
+        query_hash,
+        mode,
+        stage,
+        result.name,
+        result.engine,
+        result.confidence,
+        result.llm_required,
+        bool(result.text.strip()),
+        result.reason,
+    )
 
 
 def _get_oss_client() -> OpenAI:
@@ -328,13 +346,39 @@ async def chat_with_oss(req: ChatReq) -> dict:
         }
 
     tool_result = run_mode_tools(mode, user_text)
+    _log_tool_route(user_text, mode, "mode_tools", tool_result)
     if tool_result.resolved:
         return cache_and_return(tool_result.to_response())
 
+    grounded_fallback: ToolResult | None = None
     if mode == "oss":
         fast_path = run_oss_fast_path_tools(user_text)
+        _log_tool_route(user_text, mode, "oss_fast_path", fast_path)
         if fast_path.resolved:
             return cache_and_return(fast_path.to_response())
+
+        grounded_fallback = run_final_fallback_tools(mode, user_text)
+        _log_tool_route(user_text, mode, "oss_grounded_fallback", grounded_fallback)
+        if grounded_fallback.resolved:
+            return cache_and_return(grounded_fallback.to_response())
+
+        if grounded_fallback.llm_required and grounded_fallback.text.strip():
+            output = await call_oss_async(
+                [
+                    {
+                        "role": "system",
+                        "content": "Reasoning: low\n다음 <context>의 사실만 사용해 한국어로 한 문장으로만 답하라. 불릿/개행 금지. 임의의 전화번호/URL을 생성하지 말라.",
+                    },
+                    {"role": "user", "content": user_text + "\n\n<context>\n" + grounded_fallback.text + "\n</context>"},
+                ],
+                max_tokens=96,
+                temperature=0.2,
+                timeout=45,
+            )
+            if output:
+                latency = int((time.monotonic() - start) * 1000)
+                _log_executor.submit(_log_chatbot, user_text, "oss", output, None, False, latency)
+                return {"engine": "oss", "text": output}
 
         output = await call_oss_async(messages_for_oss)
         if not any(keyword in user_text for keyword in ("연락처", "전화", "번호", "문의")) and not any(keyword in user_text for keyword in COUNCIL_KWS):
@@ -342,6 +386,7 @@ async def chat_with_oss(req: ChatReq) -> dict:
 
         if not output:
             fallback = run_empty_oss_fallback_tools(user_text)
+            _log_tool_route(user_text, mode, "oss_empty_fallback", fallback)
             if fallback.handled:
                 response = fallback.to_response()
                 latency = int((time.monotonic() - start) * 1000)
@@ -356,7 +401,8 @@ async def chat_with_oss(req: ChatReq) -> dict:
             _log_executor.submit(_log_chatbot, user_text, "oss", output, None, False, latency)
             return {"engine": "oss", "text": output}
 
-    fallback = run_final_fallback_tools(mode, user_text)
+    fallback = grounded_fallback or run_final_fallback_tools(mode, user_text)
+    _log_tool_route(user_text, mode, "final_fallback", fallback)
     if fallback.resolved:
         return cache_and_return(fallback.to_response())
 

--- a/LLM/OSS/service.py
+++ b/LLM/OSS/service.py
@@ -421,6 +421,12 @@ async def chat_with_oss(req: ChatReq) -> dict:
             latency = int((time.monotonic() - start) * 1000)
             _log_executor.submit(_log_chatbot, user_text, "oss", output, None, False, latency)
             return {"engine": "oss", "text": output}
+        
+        if grounded_fallback is not None and not grounded_fallback.text.strip():
+            return cache_and_return({
+                "engine": "oss",
+                "text": "관련 근거를 충분히 확인하지 못했어요. 질문을 조금 더 구체적으로 다시 입력해주세요."
+            })
 
     fallback = grounded_fallback or run_final_fallback_tools(mode, user_text)
     _log_tool_route(user_text, mode, "final_fallback", fallback)

--- a/LLM/OSS/service.py
+++ b/LLM/OSS/service.py
@@ -375,10 +375,31 @@ async def chat_with_oss(req: ChatReq) -> dict:
                 temperature=0.2,
                 timeout=45,
             )
+            if not any(keyword in user_text for keyword in ("연락처", "전화", "번호", "문의")) and not any(keyword in user_text for keyword in COUNCIL_KWS):
+                output = scrub_non_contact(output)
             if output:
                 latency = int((time.monotonic() - start) * 1000)
                 _log_executor.submit(_log_chatbot, user_text, "oss", output, None, False, latency)
                 return {"engine": "oss", "text": output}
+
+            fallback = run_empty_oss_fallback_tools(user_text)
+            _log_tool_route(user_text, mode, "oss_grounded_empty_fallback", fallback)
+            if fallback.handled:
+                response = fallback.to_response()
+                latency = int((time.monotonic() - start) * 1000)
+                _log_executor.submit(_log_chatbot, user_text, response["engine"], response["text"], response.get("url"), False, latency)
+                return response
+
+            if len(user_text) <= 2 or GREETING_RE.search(user_text):
+                latency = int((time.monotonic() - start) * 1000)
+                output = "안녕하세요, 무엇을 도와드릴까요?"
+                _log_executor.submit(_log_chatbot, user_text, "greet", output, None, False, latency)
+                return {"engine": "greet", "text": output}
+
+            return cache_and_return({
+                "engine": "oss",
+                "text": "관련 근거를 충분히 확인하지 못했어요. 질문을 조금 더 구체적으로 다시 입력해 주세요.",
+            })
 
         output = await call_oss_async(messages_for_oss)
         if not any(keyword in user_text for keyword in ("연락처", "전화", "번호", "문의")) and not any(keyword in user_text for keyword in COUNCIL_KWS):

--- a/LLM/OSS/tools.py
+++ b/LLM/OSS/tools.py
@@ -25,6 +25,7 @@ class ToolResult:
     engine: str = "fast"
     confidence: float = 0.0
     llm_required: bool = False
+    reason: str = ""
 
     @property
     def resolved(self) -> bool:
@@ -41,7 +42,7 @@ class ToolResult:
         return response
 
 
-EMPTY_TOOL_RESULT = ToolResult(name="none", confidence=0.0)
+EMPTY_TOOL_RESULT = ToolResult(name="none", confidence=0.0, reason="no tool matched")
 
 
 def call_submodel(user_text: str) -> str:
@@ -80,6 +81,7 @@ def _direct_answer_tool(user_text: str, engine: str) -> ToolResult:
         url=direct.get("url"),
         engine=engine,
         confidence=0.95,
+        reason="metadata direct answer matched",
     )
 
 
@@ -98,6 +100,7 @@ def _schedule_tool(user_text: str, *, ceremonial_first: bool = False) -> ToolRes
         text=render_chatty_schedule(schedule, user_text),
         engine="fast",
         confidence=0.9,
+        reason="schedule intent matched",
     )
 
 
@@ -113,6 +116,7 @@ def _clarification_tool(user_text: str) -> ToolResult:
         text=clarification,
         engine="fast",
         confidence=0.85,
+        reason="department query needs clarification",
     )
 
 
@@ -128,6 +132,7 @@ def _postprocess_tool(mode: str, user_text: str) -> ToolResult:
         url=url,
         engine=mode,
         confidence=0.65 if text else 0.0,
+        reason=f"{mode} postprocess generated answer" if text else f"{mode} postprocess returned empty answer",
     )
 
 
@@ -144,6 +149,7 @@ def _confident_search_tool(user_text: str) -> ToolResult:
         url=confident.get("url"),
         engine="fast",
         confidence=0.85,
+        reason="high confidence search answer matched",
     )
 
 
@@ -196,6 +202,7 @@ def run_empty_oss_fallback_tools(user_text: str) -> ToolResult:
             text=render_chatty_schedule(sub_answer, user_text),
             engine="fast",
             confidence=0.7,
+            reason="schedule-like query recovered from rag context",
         )
     if sub_answer:
         mode = "topic" if looks_like_topic(user_text) else "fast"
@@ -206,6 +213,7 @@ def run_empty_oss_fallback_tools(user_text: str) -> ToolResult:
             url=url,
             engine="oss",
             confidence=0.6 if text else 0.0,
+            reason="oss returned empty answer; recovered from rag context" if text else "oss returned empty answer; rag fallback empty",
         )
     return EMPTY_TOOL_RESULT
 
@@ -224,4 +232,5 @@ def run_final_fallback_tools(mode: str, user_text: str) -> ToolResult:
         engine=mode,
         confidence=0.5,
         llm_required=True,
+        reason="no deterministic tool matched; rag context collected for grounded llm answer",
     )

--- a/tests/regression/check_chatbot_tool_routing.py
+++ b/tests/regression/check_chatbot_tool_routing.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+def install_fake_query_index() -> None:
+    module = types.ModuleType("LLM.sub_model.query_index")
+
+    def build_answer(query: str, top_k: int = 12) -> dict:
+        if "애매" in query:
+            return {"answer": "검색 근거: 학교 생활 안내 페이지에 관련 정보를 확인해야 합니다."}
+        return {"answer": ""}
+
+    def confident_search_answer(query: str, top_k: int = 2) -> dict | None:
+        if "전화번호" in query:
+            return {
+                "answer": "학생성공지원팀 전화번호는 02-2610-1234입니다.",
+                "url": "https://www.dongyang.ac.kr/contact",
+            }
+        return None
+
+    def metadata_direct_answer(query: str) -> dict | None:
+        if "졸업학점" in query:
+            return {
+                "answer": "3년제 졸업이수 학점은 총 120학점입니다.",
+                "url": "https://www.dongyang.ac.kr/grad",
+            }
+        return None
+
+    module.build_answer = build_answer
+    module.confident_search_answer = confident_search_answer
+    module.metadata_direct_answer = metadata_direct_answer
+    sys.modules["LLM.sub_model.query_index"] = module
+
+
+def install_fake_schedule_index() -> None:
+    module = types.ModuleType("LLM.sub_model.schedule_index")
+
+    def schedule_search(query: str, top_k: int = 8) -> str:
+        if "개강" in query:
+            return "2026-03-02 개강"
+        return ""
+
+    module.schedule_search = schedule_search
+    sys.modules["LLM.sub_model.schedule_index"] = module
+
+
+def check_tool_routing() -> list[str]:
+    errors = []
+    install_fake_query_index()
+    install_fake_schedule_index()
+    sys.modules.pop("LLM.OSS.tools", None)
+    tools = importlib.import_module("LLM.OSS.tools")
+
+    schedule = tools.run_mode_tools("fast", "개강 언제야?")
+    if schedule.name != "schedule_search" or not schedule.resolved:
+        errors.append(f"schedule_route_failed:{schedule}")
+    if not schedule.reason:
+        errors.append("schedule_reason_missing")
+
+    contact = tools.run_oss_fast_path_tools("학생성공지원팀 전화번호 알려줘")
+    if contact.name != "confident_search_answer" or not contact.resolved:
+        errors.append(f"contact_route_failed:{contact}")
+    if not contact.reason:
+        errors.append("contact_reason_missing")
+
+    fallback = tools.run_final_fallback_tools("oss", "애매한 학교 생활 질문")
+    if fallback.name != "rag_context_required" or not fallback.llm_required:
+        errors.append(f"fallback_route_failed:{fallback}")
+    if not fallback.text.strip():
+        errors.append("fallback_context_missing")
+    if "rag context" not in fallback.reason:
+        errors.append(f"fallback_reason_unexpected:{fallback.reason}")
+
+    return errors
+
+
+def main() -> int:
+    errors = check_tool_routing()
+    print(json.dumps({"ok": not errors, "errors": errors}, ensure_ascii=False))
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 🎯 배경

- OSS 챗봇은 실제 Agent tool calling이 아니라 Ollama 기반 RAG 응답 구조이므로, 서버 주도 pseudo tool routing 형태로 흐름을 명확히 정리할 필요가 있었습니다.
- 애매한 질의가 바로 자유형 Ollama 호출로 빠지지 않도록 RAG context 기반 방어선을 추가하고, 라우팅 결과를 추적 가능하게 만들었습니다.

## 🔍 주요 내용

- `ToolResult`에 `reason`을 추가해 pseudo tool 라우팅 사유를 남기도록 개선
- 챗봇 서비스에 `chatbot_tool_route` 로그 추가
- `oss` 모드에서 fast path 이후 RAG context 기반 grounded fallback을 먼저 시도하도록 조정
- fake module 기반 lightweight chatbot tool routing 회귀 테스트 추가
- RAG light check workflow에 chatbot routing 체크 포함
- 로컬 RAG 평가 리포트 폴더를 `.gitignore`에 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 변경 요약(1~3줄)  
OSS 챗봇의 서버 주도형(의사) 도구 라우팅을 명확히 하기 위해 ToolResult에 라우팅 근거(reason)를 추가하고 단계별 라우팅 로깅을 도입했습니다. OSS 모드에서 빠른 경로 후 RAG 컨텍스트 기반의 근거 있는 폴백을 우선 시도하도록 흐름을 재구성했습니다.

## 주요 변경점
  - ToolResult에 reason: str 필드 추가로 라우팅 근거 기록
  - _log_tool_route() 추가 및 chatbot_tool_route 로깅으로 쿼리 해시/모드/스테이지/도구/신뢰도/llm_required/사유 추적
  - OSS 흐름 재구성: mode_tools → oss_fast_path → grounded_fallback(run_final_fallback_tools) → LLM 호출 → empty_fallback
  - grounded_fallback의 텍스트 유무·llm_required 체크와 빈 응답 시 추가 분기(oss_empty_fallback, oss_grounded_empty_fallback) 처리
  - 회귀 테스트 추가: tests/regression/check_chatbot_tool_routing.py (가짜 모듈로 라우팅 경로 검증)
  - CI 통합: .github/workflows/rag-light-check.yml에 챗봇 라우팅 체크 추가
  - .gitignore에 로컬 RAG 평가 리포트 폴더(tests/regression/reports/) 추가

## 주의/리스크
  - 라우팅 흐름이 복잡해져 의도치 않은 경로 선택 가능성 — 추가 검증 필요
  - 쿼리별 상세 로깅으로 인한 성능/저장 오버헤드 모니터링 필요

## 다음 액션
  - 실제 트래픽에서 RAG 기반 폴백의 정확도와 LLM 호출 감소 효과 검증
  - 로깅 결과를 바탕으로 자주 잘못 라우팅되는 패턴 식별 후 규칙/우선순위 조정

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dongsooop/AI/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->