### PR TITLE
chore: add ai eval report foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__
 .ipynb_checkpoints/
 hs_err_pid*.log
 tests/regression/**/reports/
+tests/reports/**/*.json
 
 # Local dependencies
 requirements.txt

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -12,3 +12,39 @@ python tests/regression/chatbot/evaluate_rag_retrieval.py --validate-only
 python tests/regression/chatbot/check_chatbot_tool_routing.py
 python tests/regression/timetable/check_timetable_ocr_diagnostics.py
 ```
+
+## Evaluation Metrics Policy
+
+회귀 스크립트는 로컬과 CI에서 평가 지표를 JSON summary로 출력하고, 상세 리포트를 기능별 디렉터리에 저장합니다. 이 기반 단계에서는 새 지표를 실패 조건으로 강제하지 않고, 기존 테스트의 통과/실패 판정만 유지합니다.
+
+리포트 기본 저장 위치:
+
+- `tests/reports/chatbot/`: 챗봇, RAG 검색, query-index 리포트
+- `tests/reports/timetable/`: 시간표 OCR, 이미지 품질 진단 리포트
+- `tests/reports/text_filtering/`: 텍스트 필터링 리포트
+
+`tests/reports/**/*.json` 파일은 실행 산출물이므로 커밋하지 않습니다. 공유가 필요한 기준 리포트나 샘플은 별도 문서로 의도를 설명한 뒤 추가합니다.
+
+## Common JSON Summary
+
+각 리포트는 가능한 한 아래 summary 형식을 따릅니다. 상세 지표는 suite마다 다를 수 있으므로 `metrics` 안에 둡니다.
+
+```json
+{
+  "schema_version": 1,
+  "suite": "timetable_ocr_diagnostics",
+  "service": "timetable",
+  "status": "passed",
+  "total": 1,
+  "passed": 1,
+  "failed": 0,
+  "skipped": 0,
+  "metrics": {
+    "average_confidence": 87.33,
+    "fallback_cells": 1
+  },
+  "errors": []
+}
+```
+
+CI에서는 summary 한 줄과 `report=<path>` 출력을 수집합니다. 리포트 파일은 기본 경로를 쓰되, 필요한 경우 각 스크립트의 `--out` 옵션으로 저장 위치를 바꿀 수 있습니다.

--- a/tests/regression/chatbot/check_query_index_compat.py
+++ b/tests/regression/chatbot/check_query_index_compat.py
@@ -15,6 +15,7 @@ import pandas as pd
 ROOT_DIR = Path(__file__).resolve().parents[3]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
+DEFAULT_REPORT_PATH = ROOT_DIR / "tests" / "reports" / "chatbot" / "query_index_compat_report.json"
 
 from LLM.sub_model.query_index_schema import (  # noqa: E402
     METADATA_BOOL_COLS,
@@ -230,7 +231,7 @@ def main() -> int:
     ap.add_argument(
         "--out",
         default="",
-        help="optional JSON report path; defaults to a temp file",
+        help="optional JSON report path",
     )
     args = ap.parse_args()
 
@@ -254,7 +255,7 @@ def main() -> int:
         "errors": errors,
     }
 
-    out_path = Path(args.out) if args.out else Path("/tmp/query_index_compat_report.json")
+    out_path = Path(args.out) if args.out else DEFAULT_REPORT_PATH
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
 

--- a/tests/regression/chatbot/check_query_index_metadata_quality.py
+++ b/tests/regression/chatbot/check_query_index_metadata_quality.py
@@ -15,6 +15,7 @@ import pandas as pd
 ROOT_DIR = Path(__file__).resolve().parents[3]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
+DEFAULT_REPORT_PATH = ROOT_DIR / "tests" / "reports" / "chatbot" / "query_index_metadata_quality_report.json"
 
 
 def install_fake_sentence_transformer() -> None:
@@ -372,7 +373,7 @@ def main() -> int:
         "errors": errors,
     }
 
-    out_path = Path(args.out) if args.out else Path("/tmp/query_index_metadata_quality_report.json")
+    out_path = Path(args.out) if args.out else DEFAULT_REPORT_PATH
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
 

--- a/tests/regression/chatbot/evaluate_rag_retrieval.py
+++ b/tests/regression/chatbot/evaluate_rag_retrieval.py
@@ -18,6 +18,7 @@ URL_RE = re.compile(r"https?://[^\s)>\]}\"']+")
 
 
 DEFAULT_CASES_PATH = Path(__file__).with_name("rag_eval_cases.json")
+DEFAULT_REPORT_PATH = ROOT_DIR / "tests" / "reports" / "chatbot" / "rag_eval_report.json"
 
 
 def _load_cases_file(path: Path) -> list[dict]:
@@ -422,7 +423,7 @@ def main() -> int:
     ap.add_argument("--top-k", type=int, default=5, help="hybrid_search top_k for retrieval metrics")
     ap.add_argument("--answer-top-k", type=int, default=6, help="build_answer top_k for answer metrics")
     ap.add_argument("--schedule-top-k", type=int, default=5, help="schedule_search top_k for schedule cases")
-    ap.add_argument("--out", default="/tmp/rag_eval_report.json", help="output report path")
+    ap.add_argument("--out", default=str(DEFAULT_REPORT_PATH), help="output report path")
     ap.add_argument("--fail-on-fail", action="store_true", help="exit 2 when any case fails")
     ap.add_argument("--validate-only", action="store_true", help="validate case schema without importing RAG runtime")
     args = ap.parse_args()

--- a/tests/regression/chatbot/run_chatbot_regression.py
+++ b/tests/regression/chatbot/run_chatbot_regression.py
@@ -8,6 +8,9 @@ from pathlib import Path
 from urllib import request, error
 from urllib.parse import urlparse
 
+ROOT_DIR = Path(__file__).resolve().parents[3]
+DEFAULT_REPORT_PATH = ROOT_DIR / "tests" / "reports" / "chatbot" / "chatbot_regression_report.json"
+
 
 def load_cases(path: Path):
     with path.open("r", encoding="utf-8") as f:
@@ -178,7 +181,7 @@ def main():
     if args.baseline:
         report["comparison"] = compare_with_baseline(results, Path(args.baseline))
 
-    out_path = Path(args.out) if args.out else Path("/tmp/chatbot_regression_report.json")
+    out_path = Path(args.out) if args.out else DEFAULT_REPORT_PATH
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
 

--- a/tests/regression/timetable/check_timetable_ocr_diagnostics.py
+++ b/tests/regression/timetable/check_timetable_ocr_diagnostics.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import argparse
+import json
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -6,6 +8,7 @@ from unittest.mock import patch
 ROOT_DIR = Path(__file__).resolve().parents[3]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
+DEFAULT_REPORT_PATH = ROOT_DIR / "tests" / "reports" / "timetable" / "timetable_ocr_diagnostics_report.json"
 
 try:
     import cv2
@@ -45,6 +48,10 @@ def fake_image_to_data(*args, **kwargs) -> dict:
 
 
 def main() -> int:
+    ap = argparse.ArgumentParser(description="Check timetable OCR diagnostics contract")
+    ap.add_argument("--out", default=str(DEFAULT_REPORT_PATH), help="output report path")
+    args = ap.parse_args()
+
     image = make_synthetic_timetable()
     quality = assess_image_quality(image)
     errors = []
@@ -91,12 +98,47 @@ def main() -> int:
     if call_counts["data"] != 0:
         errors.append(f"fast_path_called_confidence_ocr:{call_counts}")
 
+    average_confidence = ocr.get("average_confidence")
+    summary = {
+        "schema_version": 1,
+        "suite": "timetable_ocr_diagnostics",
+        "service": "timetable",
+        "status": "failed" if errors else "passed",
+        "total": 1,
+        "passed": 0 if errors else 1,
+        "failed": 1 if errors else 0,
+        "skipped": 0,
+        "metrics": {
+            "average_confidence": average_confidence,
+            "fallback_cells": ocr.get("fallback_cells", 0),
+            "accepted_cells": ocr.get("accepted_cells", 0),
+            "rejected_cells": len(ocr.get("rejected_cells", [])),
+            "schedule_count": diagnostics.get("schedule_count", 0),
+        },
+        "errors": errors,
+    }
+    output = {
+        "schema_version": 1,
+        "suite": "timetable_ocr_diagnostics",
+        "service": "timetable",
+        "summary": summary,
+        "diagnostics": diagnostics,
+        "fast_path_call_counts": call_counts,
+    }
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(output, ensure_ascii=False, indent=2), encoding="utf-8")
+
     if errors:
         for error in errors:
             print(f"[FAIL] {error}")
+        print(json.dumps(summary, ensure_ascii=False))
+        print(f"report={out_path}")
         return 1
 
     print("[OK] timetable OCR diagnostics contract")
+    print(json.dumps(summary, ensure_ascii=False))
+    print(f"report={out_path}")
     return 0
 
 

--- a/tests/reports/README.md
+++ b/tests/reports/README.md
@@ -1,0 +1,9 @@
+# Regression Reports
+
+회귀 테스트 실행 리포트는 기능별 하위 디렉터리에 저장합니다.
+
+- `chatbot/`: 챗봇, RAG 검색, query-index 리포트
+- `timetable/`: 시간표 OCR 진단 리포트
+- `text_filtering/`: 텍스트 필터링 리포트
+
+생성된 `*.json` 리포트는 로컬/CI 산출물이므로 기본적으로 커밋하지 않습니다.


### PR DESCRIPTION
## 🎯 배경

- 회귀 테스트와 AI 평가 지표를 로컬/CI에서 일관된 형식으로 확인할 수 있도록 공통 리포트 저장 정책이 필요했습니다.
- 기능별 리포트 저장 위치와 JSON summary 형식을 먼저 정리해 후속 평가 지표 작업의 기반을 마련합니다.

## 🔍 주요 내용

- `tests/reports/<기능>/` 기준의 리포트 저장 정책을 문서화했습니다.
- `tests/reports/**/*.json`를 ignore 처리해 실행 산출물이 커밋되지 않도록 했습니다.
- 챗봇 회귀/평가 스크립트의 기본 리포트 경로를 `tests/reports/chatbot/`로 변경했습니다.
- 시간표 OCR 진단 스크립트에 `--out` 옵션과 공통 summary JSON 리포트 출력을 추가했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 요약
회귀 테스트와 AI 평가 지표를 일관된 형식으로 저장하고 관리하기 위한 리포트 정책을 수립했습니다. 기본 리포트 출력 경로를 `/tmp`에서 `tests/reports/<feature>/`로 통일하고, timetable OCR 진단 스크립트에 리포트 출력 기능을 추가했습니다.

## 주요 변경점
- `.gitignore`에 `tests/reports/**/*.json` 패턴 추가 → 생성된 리포트는 커밋 대상 제외
- `tests/regression/README.md`에 리포트 저장 정책 문서화 → 로컬/CI 환경 모두에서 일관된 형식 사용 규정
- chatbot 회귀 테스트 4개 파일의 기본 리포트 경로 변경 → `/tmp/*` → `tests/reports/chatbot/*`
- `DEFAULT_REPORT_PATH` 상수 추가 → 각 스크립트의 기본 출력 경로 명시
- timetable OCR 진단 스크립트에 `--out` 옵션 및 JSON 리포트 기능 구현 → summary와 diagnostics 데이터 포함
- `tests/reports/README.md` 추가 → 기능별 디렉터리(chatbot, timetable, text_filtering) 용도 설명

## 주의/리스크
- 기존에 `/tmp`에 저장되던 리포트 파일들이 새 위치로 변경되므로, CI/자동화 파이프라인에서 리포트 경로 참조 부분 확인 필요
- timetable OCR 스크립트는 새로운 리포트 기능이 추가되었으므로, 기존 스크립트를 호출하는 곳에서 예상치 못한 출력 증가 가능

## 다음 액션
- CI 설정에서 리포트 수집 경로가 `tests/reports/` 하위를 바라보는지 검증 필요
- 기존에 `/tmp` 경로를 직접 참조하는 모니터링/대시보드 도구 있으면 업데이트 필요

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dongsooop/AI/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->