### PR TITLE
test: extend rag retrieval evaluation summary

### DIFF
--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -9,6 +9,7 @@
 
 ```bash
 python tests/regression/chatbot/evaluate_rag_retrieval.py --validate-only
+python tests/regression/chatbot/evaluate_rag_retrieval.py
 python tests/regression/chatbot/check_chatbot_tool_routing.py
 python tests/regression/timetable/check_timetable_ocr_diagnostics.py
 ```
@@ -24,6 +25,19 @@ python tests/regression/timetable/check_timetable_ocr_diagnostics.py
 - `tests/reports/text_filtering/`: 텍스트 필터링 리포트
 
 `tests/reports/**/*.json` 파일은 실행 산출물이므로 커밋하지 않습니다. 공유가 필요한 기준 리포트나 샘플은 별도 문서로 의도를 설명한 뒤 추가합니다.
+
+### Chatbot RAG Product Metrics
+
+`tests/regression/chatbot/evaluate_rag_retrieval.py`는 챗봇 RAG 품질을 제품 관점 지표로 함께 출력합니다.
+
+- `recall_at_1`: 검색 결과 1위 URL이 케이스의 `expected_url_contains`와 일치한 비율
+- `recall_at_3`: 검색 결과 상위 3개 URL 중 하나가 `expected_url_contains`와 일치한 비율
+- `source_url_pass_rate`: 출처 URL이 필요한 search 케이스에서 답변이 기대 출처 URL을 포함한 비율
+- `unofficial_url_hallucination_rate`: 답변에 공식 학교 도메인 또는 검색 근거에 없는 외부 URL이 포함된 비율
+- `refusal_rate`: 평가 답변이 거절/fallback 문구로 판정된 비율
+- `refusal_expectation_pass_rate`: `expects_refusal` 케이스 설정과 실제 거절 여부가 일치한 비율
+
+카테고리별 결과는 `summary.by_category`에 `passed`, `failed`, `pass_rate`와 함께 같은 제품 지표 일부를 저장합니다. 현재 RAG 평가는 `LLM.sub_model.query_index.build_answer()`와 `schedule_search()`를 직접 호출하므로, API/LLM 라우팅 전체의 거절 정책 평가는 별도 API 회귀 테스트에서 다룹니다.
 
 ## Common JSON Summary
 

--- a/tests/regression/chatbot/evaluate_rag_retrieval.py
+++ b/tests/regression/chatbot/evaluate_rag_retrieval.py
@@ -15,6 +15,22 @@ if str(ROOT_DIR) not in sys.path:
 
 DATE_RE = re.compile(r"\b20\d{2}-\d{2}-\d{2}\b")
 URL_RE = re.compile(r"https?://[^\s)>\]}\"']+")
+REFUSAL_RE = re.compile(
+    r"("
+    r"답변할\s*수\s*없|"
+    r"확인할\s*수\s*없|"
+    r"제공할\s*수\s*없|"
+    r"제공하기\s*어렵|"
+    r"찾을\s*수\s*없|"
+    r"찾지\s*못|"
+    r"자료가\s*없|"
+    r"정보가\s*없|"
+    r"알\s*수\s*없|"
+    r"모르겠|"
+    r"범위\s*밖|"
+    r"관련\s*정보.*없"
+    r")"
+)
 
 
 DEFAULT_CASES_PATH = Path(__file__).with_name("rag_eval_cases.json")
@@ -76,7 +92,7 @@ def validate_cases(cases: list[dict]) -> list[str]:
         "answer_must_contain_any",
         "answer_must_contain_all",
     ]
-    bool_fields = ["requires_source_url", "requires_date"]
+    bool_fields = ["requires_source_url", "requires_date", "expects_refusal"]
 
     for idx, case in enumerate(cases, start=1):
         case_id = str(case.get("id", "") or "")
@@ -106,12 +122,16 @@ def validate_cases(cases: list[dict]) -> list[str]:
 
         if kind == "search":
             has_expected_source = bool(case.get("expected_url_contains") or case.get("expected_title_contains"))
-            if not has_expected_source:
+            if not has_expected_source and not case.get("expects_refusal", False):
                 errors.append(f"{prefix}:missing_expected_source")
             if case.get("requires_source_url") and not case.get("expected_url_contains"):
                 errors.append(f"{prefix}:requires_source_without_expected_url")
 
-        if not (case.get("answer_must_contain_any") or case.get("answer_must_contain_all")):
+        if not (
+            case.get("answer_must_contain_any")
+            or case.get("answer_must_contain_all")
+            or case.get("expects_refusal", False)
+        ):
             errors.append(f"{prefix}:missing_answer_expectation")
     return errors
 
@@ -145,6 +165,10 @@ def contains_any(text: str, needles: list[str]) -> bool:
 
 def contains_all(text: str, needles: list[str]) -> bool:
     return all(needle in text for needle in needles)
+
+
+def is_refusal_answer(text: str) -> bool:
+    return bool(REFUSAL_RE.search(text or ""))
 
 
 def urls_from_hits(hits) -> list[str]:
@@ -211,7 +235,11 @@ def evaluate_search_case(case: dict, top_k: int, answer_top_k: int) -> dict:
             "top1_title_match": False,
             "answer_keyword_match": False,
             "source_url_match": False if case.get("requires_source_url", False) else True,
+            "source_url_required": bool(case.get("requires_source_url", False)),
             "date_match": True,
+            "refused": False,
+            "expected_refusal": bool(case.get("expects_refusal", False)),
+            "refusal_match": not bool(case.get("expects_refusal", False)),
             "hallucination_detected": False,
             "hallucination_flags": [],
             "expected_url_rank": None,
@@ -256,6 +284,9 @@ def evaluate_search_case(case: dict, top_k: int, answer_top_k: int) -> dict:
     answer_any = contains_any(answer, case.get("answer_must_contain_any", []))
     answer_all = contains_all(answer, case.get("answer_must_contain_all", []))
     date_pass = bool(DATE_RE.search(answer)) if case.get("requires_date", False) else True
+    refused = is_refusal_answer(answer)
+    expected_refusal = bool(case.get("expects_refusal", False))
+    refusal_match = refused if expected_refusal else not refused
     hallu = hallucination_flags(answer, hits, expected_urls)
 
     return {
@@ -268,7 +299,11 @@ def evaluate_search_case(case: dict, top_k: int, answer_top_k: int) -> dict:
         "top1_title_match": title_matches(hits, case.get("expected_title_contains", [])),
         "answer_keyword_match": answer_any and answer_all,
         "source_url_match": source_url_match,
+        "source_url_required": bool(case.get("requires_source_url", False)),
         "date_match": date_pass,
+        "refused": refused,
+        "expected_refusal": expected_refusal,
+        "refusal_match": refusal_match,
         "hallucination_detected": bool(hallu),
         "hallucination_flags": hallu,
         "expected_url_rank": url_rank,
@@ -285,10 +320,11 @@ def evaluate_search_case(case: dict, top_k: int, answer_top_k: int) -> dict:
         "passed": all([
             not retrieval_error,
             not answer_error,
-            top3_url_match if expected_urls else True,
+            top3_url_match if expected_urls and not expected_refusal else True,
             answer_any and answer_all,
             source_url_match,
             date_pass,
+            refusal_match,
             not hallu,
         ]),
     }
@@ -311,7 +347,11 @@ def evaluate_schedule_case(case: dict, top_k: int) -> dict:
             "top1_title_match": None,
             "answer_keyword_match": False,
             "source_url_match": True,
+            "source_url_required": False,
             "date_match": False if case.get("requires_date", False) else True,
+            "refused": False,
+            "expected_refusal": bool(case.get("expects_refusal", False)),
+            "refusal_match": not bool(case.get("expects_refusal", False)),
             "hallucination_detected": False,
             "hallucination_flags": [],
             "expected_url_rank": None,
@@ -339,6 +379,9 @@ def evaluate_schedule_case(case: dict, top_k: int) -> dict:
     answer_any = contains_any(answer, case.get("answer_must_contain_any", []))
     answer_all = contains_all(answer, case.get("answer_must_contain_all", []))
     date_pass = bool(DATE_RE.search(answer)) if case.get("requires_date", False) else True
+    refused = is_refusal_answer(answer)
+    expected_refusal = bool(case.get("expects_refusal", False))
+    refusal_match = refused if expected_refusal else not refused
 
     return {
         "id": case.get("id"),
@@ -350,7 +393,11 @@ def evaluate_schedule_case(case: dict, top_k: int) -> dict:
         "top1_title_match": None,
         "answer_keyword_match": answer_any and answer_all,
         "source_url_match": True,
+        "source_url_required": False,
         "date_match": date_pass,
+        "refused": refused,
+        "expected_refusal": expected_refusal,
+        "refusal_match": refusal_match,
         "hallucination_detected": False,
         "hallucination_flags": [],
         "expected_url_rank": None,
@@ -363,7 +410,7 @@ def evaluate_schedule_case(case: dict, top_k: int) -> dict:
         },
         "retrieval_latency_ms": latency_ms,
         "answer_latency_ms": 0.0,
-        "passed": all([not error, answer_any and answer_all, date_pass]),
+        "passed": all([not error, answer_any and answer_all, date_pass, refusal_match]),
     }
 
 
@@ -374,26 +421,53 @@ def pct(numerator: int, denominator: int) -> float:
 def summarize(results: list[dict]) -> dict:
     search_results = [r for r in results if r["kind"] == "search"]
     schedule_results = [r for r in results if r["kind"] == "schedule"]
+    source_required_results = [r for r in search_results if r.get("source_url_required")]
     latencies = [float(r.get("retrieval_latency_ms", 0.0)) for r in results]
     answer_latencies = [float(r.get("answer_latency_ms", 0.0)) for r in search_results]
+    passed = sum(1 for r in results if r["passed"])
+    failed = sum(1 for r in results if not r["passed"])
 
-    summary = {
-        "total": len(results),
-        "passed": sum(1 for r in results if r["passed"]),
-        "failed": sum(1 for r in results if not r["passed"]),
-        "pass_rate": pct(sum(1 for r in results if r["passed"]), len(results)),
-        "search_total": len(search_results),
-        "schedule_total": len(schedule_results),
-        "top1_url_accuracy": pct(sum(1 for r in search_results if r["top1_url_match"]), len(search_results)),
-        "top3_url_accuracy": pct(sum(1 for r in search_results if r["top3_url_match"]), len(search_results)),
-        "top1_title_accuracy": pct(sum(1 for r in search_results if r["top1_title_match"]), len(search_results)),
-        "answer_keyword_pass_rate": pct(sum(1 for r in results if r["answer_keyword_match"]), len(results)),
-        "source_url_pass_rate": pct(sum(1 for r in search_results if r["source_url_match"]), len(search_results)),
-        "date_pass_rate": pct(sum(1 for r in results if r["date_match"]), len(results)),
-        "hallucination_proxy_rate": pct(
+    metrics = {
+        "recall_at_1": pct(sum(1 for r in search_results if r["top1_url_match"]), len(search_results)),
+        "recall_at_3": pct(sum(1 for r in search_results if r["top3_url_match"]), len(search_results)),
+        "source_url_pass_rate": pct(
+            sum(1 for r in source_required_results if r["source_url_match"]),
+            len(source_required_results),
+        ),
+        "unofficial_url_hallucination_rate": pct(
             sum(1 for r in search_results if r["hallucination_detected"]),
             len(search_results),
         ),
+        "refusal_rate": pct(sum(1 for r in results if r.get("refused")), len(results)),
+        "refusal_expectation_pass_rate": pct(sum(1 for r in results if r.get("refusal_match")), len(results)),
+    }
+
+    summary = {
+        "schema_version": 1,
+        "suite": "rag_retrieval",
+        "service": "chatbot",
+        "status": "passed" if failed == 0 else "failed",
+        "total": len(results),
+        "passed": passed,
+        "failed": failed,
+        "skipped": 0,
+        "pass_rate": pct(passed, len(results)),
+        "search_total": len(search_results),
+        "schedule_total": len(schedule_results),
+        "top1_url_accuracy": metrics["recall_at_1"],
+        "top3_url_accuracy": metrics["recall_at_3"],
+        "recall_at_1": metrics["recall_at_1"],
+        "recall_at_3": metrics["recall_at_3"],
+        "top1_title_accuracy": pct(sum(1 for r in search_results if r["top1_title_match"]), len(search_results)),
+        "answer_keyword_pass_rate": pct(sum(1 for r in results if r["answer_keyword_match"]), len(results)),
+        "source_url_pass_rate": metrics["source_url_pass_rate"],
+        "date_pass_rate": pct(sum(1 for r in results if r["date_match"]), len(results)),
+        "hallucination_proxy_rate": metrics["unofficial_url_hallucination_rate"],
+        "unofficial_url_hallucination_rate": metrics["unofficial_url_hallucination_rate"],
+        "refusal_rate": metrics["refusal_rate"],
+        "refusal_expectation_pass_rate": metrics["refusal_expectation_pass_rate"],
+        "metrics": metrics,
+        "errors": [],
         "avg_retrieval_latency_ms": round(statistics.mean(latencies), 2) if latencies else 0.0,
         "p95_retrieval_latency_ms": round(statistics.quantiles(latencies, n=20)[18], 2) if len(latencies) >= 20 else 0.0,
         "avg_answer_latency_ms": round(statistics.mean(answer_latencies), 2) if answer_latencies else 0.0,
@@ -403,11 +477,26 @@ def summarize(results: list[dict]) -> dict:
     for category in sorted({r["category"] for r in results}):
         items = [r for r in results if r["category"] == category]
         searches = [r for r in items if r["kind"] == "search"]
+        source_required = [r for r in searches if r.get("source_url_required")]
         by_category[category] = {
             "total": len(items),
+            "passed": sum(1 for r in items if r["passed"]),
+            "failed": sum(1 for r in items if not r["passed"]),
             "pass_rate": pct(sum(1 for r in items if r["passed"]), len(items)),
+            "recall_at_1": pct(sum(1 for r in searches if r["top1_url_match"]), len(searches)),
+            "recall_at_3": pct(sum(1 for r in searches if r["top3_url_match"]), len(searches)),
             "top3_url_accuracy": pct(sum(1 for r in searches if r["top3_url_match"]), len(searches)),
             "answer_keyword_pass_rate": pct(sum(1 for r in items if r["answer_keyword_match"]), len(items)),
+            "source_url_pass_rate": pct(
+                sum(1 for r in source_required if r["source_url_match"]),
+                len(source_required),
+            ),
+            "unofficial_url_hallucination_rate": pct(
+                sum(1 for r in searches if r["hallucination_detected"]),
+                len(searches),
+            ),
+            "refusal_rate": pct(sum(1 for r in items if r.get("refused")), len(items)),
+            "refusal_expectation_pass_rate": pct(sum(1 for r in items if r.get("refusal_match")), len(items)),
         }
     summary["by_category"] = by_category
     return summary
@@ -476,6 +565,8 @@ def main() -> int:
                 reasons.append("source_url")
             if not r["date_match"]:
                 reasons.append("date")
+            if not r.get("refusal_match", True):
+                reasons.append("refusal")
             if r["hallucination_detected"]:
                 reasons.append("hallucination_proxy")
             for stage, error in (r.get("errors") or {}).items():


### PR DESCRIPTION
## 🎯 배경

- 챗봇 RAG 품질을 단순 pass/fail뿐 아니라 제품 관점 지표로 설명할 수 있도록 평가 리포트를 확장합니다.
- 검색 recall, 출처 URL 포함 여부, 비공식 URL 환각, 거절률을 숫자로 확인할 수 있게 합니다.

## 🔍 주요 내용

- `evaluate_rag_retrieval.py`에 `recall_at_1`, `recall_at_3`, `source_url_pass_rate`, `unofficial_url_hallucination_rate`, `refusal_rate` 지표를 추가했습니다.
- `summary.metrics`와 `summary.by_category`에 전체/카테고리별 품질 지표를 포함하도록 리포트 구조를 확장했습니다.
- 향후 거절 기대 케이스를 추가할 수 있도록 `expects_refusal` 검증 필드를 지원했습니다.
- `tests/regression/README.md`에 챗봇 RAG 제품 지표 정의와 실행 명령을 문서화했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 요약
RAG 챗봇 평가 시스템을 단순 패스/실패에서 제품 지향적 메트릭으로 확대하여, 거절(Refusal) 케이스 평가를 새로 지원하고 5가지 평가 지표와 카테고리별 상세 분석 기능을 추가했습니다.

## 주요 변경점
- **거절 평가 기능 추가**: `expects_refusal` 필드 지원으로 거절 응답을 별도 신호로 처리 가능
- **새로운 평가 지표 5개**: recall_at_1, recall_at_3, source_url_pass_rate, unofficial_url_hallucination_rate, refusal_rate 추가
- **함수 및 상수 추가**: `is_refusal_answer()` 함수와 `REFUSAL_RE` 정규식 신규 생성
- **보고서 구조 확장**: summary.metrics(전체 지표)와 summary.by_category(카테고리별 상세 결과) 지원
- **평가 판정 로직 개선**: 거절 일치 여부(`refusal_match`)를 기존 URL/키워드 조건과 함께 반영
- **문서화 강화**: README.md에 "Chatbot RAG Product Metrics" 섹션 추가로 각 지표 정의 및 실행 방법 안내

## 주의/리스크
- 새로운 `expects_refusal` 필드가 기존 테스트 케이스와의 하위 호환성에 영향을 미칠 수 있으므로 기존 테스트 데이터 검증 필요
- 거절 정책 평가가 별도 API 회귀 테스트와 분리되어 있으므로 용도 구분에 주의

## 다음 액션
- 거절 케이스를 포함한 새로운 테스트 데이터셋 추가
- 새로운 메트릭이 정확하게 계산되는지 테스트 케이스로 검증
- 기존 RAG 평가 테스트와의 호환성 확인

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dongsooop/AI/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->