### PR TITLE
fix: resolve spaced doit chatbot query

### DIFF
--- a/LLM/sub_model/query_index.py
+++ b/LLM/sub_model/query_index.py
@@ -74,7 +74,10 @@ ANSWER_TEXT_COL = "text_for_answer"
 PRIVACY_QUERY_RE = re.compile(r"(개인정보|영상정보|처리방침|이메일\s*무단|이전방침|이용안내)")
 POLICY_QUERY_RE = re.compile(r"(휴학|복학|등록|장학|졸업|수강|학칙|규정|절차|신청|자격|요건)")
 INTRO_QUERY_RE = re.compile(r"(소개|비전|상징|로고|캐릭터|연혁|학과|학부|전공)")
-SPACED_DO_IT_RE = re.compile(r"(?<![A-Za-z])do\s+it(?![A-Za-z])", re.I)
+SPACED_DO_IT_RE = re.compile(
+    r"(?<![A-Za-z])do\s+it(?=\s*(?:[이가은는를란]|뭐|무엇|시스템|학생|동양|학교))",
+    re.I,
+)
 COMPACT_DOIT_RE = re.compile(r"(?<![A-Za-z])doit(?![A-Za-z])", re.I)
 DOIT_URL = "https://doit.dongyang.ac.kr/main/Login.aspx"
 
@@ -231,12 +234,16 @@ def _text_match_score(text: str, terms: list[str]) -> int:
 def _compact(s: str) -> str:
     return re.sub(r"\s+", "", (s or "").lower())
 
+
 def _looks_like_doit_query(query: str) -> bool:
     text = query or ""
     return bool(SPACED_DO_IT_RE.search(text) or COMPACT_DOIT_RE.search(text))
 
+
 def _normalize_doit_query(query: str) -> str:
+    # Compact "doit" is already the school-system token; only spaced variants need folding.
     return SPACED_DO_IT_RE.sub("DOIT", query or "")
+
 
 def _metadata_doit_answer(query: str) -> dict | None:
     if not _looks_like_doit_query(query):
@@ -249,6 +256,12 @@ def _metadata_doit_answer(query: str) -> dict | None:
         ),
         "url": DOIT_URL,
     }
+
+
+def _doit_direct_answer(query: str) -> dict | None:
+    """Handle only DOIT aliases before general retrieval without changing other direct-answer flows."""
+    return _metadata_doit_answer(query)
+
 
 def _query_terms(query: str):
     stop = set(CONTACT_KWS) | {
@@ -381,7 +394,7 @@ def metadata_direct_answer(query: str) -> dict | None:
 
 def confident_search_answer(query: str, top_k: int = 3) -> dict | None:
     """Return a compact source-grounded answer when retrieval confidence is strong enough."""
-    direct = _metadata_doit_answer(query)
+    direct = _doit_direct_answer(query)
     if direct:
         return direct
 
@@ -548,7 +561,7 @@ def hybrid_search(query, top_k=8, alpha=DEFAULT_DENSE_WEIGHT, contact_boost=CONT
     return out.reset_index(drop=True)
 
 def build_answer(query, top_k=6):
-    direct = _metadata_doit_answer(query)
+    direct = _doit_direct_answer(query)
     if direct:
         return direct
 

--- a/LLM/sub_model/query_index.py
+++ b/LLM/sub_model/query_index.py
@@ -395,7 +395,7 @@ def metadata_direct_answer(query: str) -> dict | None:
 def confident_search_answer(query: str, top_k: int = 3) -> dict | None:
     """Return a compact source-grounded answer when retrieval confidence is strong enough."""
     direct = _doit_direct_answer(query)
-    if direct:
+    if direct and not any(k in query for k in CONTACT_KWS):
         return direct
 
     hits = hybrid_search(query, top_k=max(top_k, 3))

--- a/LLM/sub_model/query_index.py
+++ b/LLM/sub_model/query_index.py
@@ -74,6 +74,9 @@ ANSWER_TEXT_COL = "text_for_answer"
 PRIVACY_QUERY_RE = re.compile(r"(개인정보|영상정보|처리방침|이메일\s*무단|이전방침|이용안내)")
 POLICY_QUERY_RE = re.compile(r"(휴학|복학|등록|장학|졸업|수강|학칙|규정|절차|신청|자격|요건)")
 INTRO_QUERY_RE = re.compile(r"(소개|비전|상징|로고|캐릭터|연혁|학과|학부|전공)")
+SPACED_DO_IT_RE = re.compile(r"(?<![A-Za-z])do\s+it(?![A-Za-z])", re.I)
+COMPACT_DOIT_RE = re.compile(r"(?<![A-Za-z])doit(?![A-Za-z])", re.I)
+DOIT_URL = "https://doit.dongyang.ac.kr/main/Login.aspx"
 
 def _canonical_unit_from_query(q: str) -> str | None:
     toks = re.findall(HANGUL_TOKEN_PATTERN, q or "")
@@ -228,6 +231,25 @@ def _text_match_score(text: str, terms: list[str]) -> int:
 def _compact(s: str) -> str:
     return re.sub(r"\s+", "", (s or "").lower())
 
+def _looks_like_doit_query(query: str) -> bool:
+    text = query or ""
+    return bool(SPACED_DO_IT_RE.search(text) or COMPACT_DOIT_RE.search(text))
+
+def _normalize_doit_query(query: str) -> str:
+    return SPACED_DO_IT_RE.sub("DOIT", query or "")
+
+def _metadata_doit_answer(query: str) -> dict | None:
+    if not _looks_like_doit_query(query):
+        return None
+    return {
+        "answer": (
+            "DOIT는 동양미래대학교의 학생종합관리시스템입니다. "
+            "학교 자료에는 학생종합관리 DOIT, 학생종합관리시스템(DOIT)로 표시되어 있으며, "
+            f"접속 주소는 {DOIT_URL} 입니다."
+        ),
+        "url": DOIT_URL,
+    }
+
 def _query_terms(query: str):
     stop = set(CONTACT_KWS) | {
         "알려줘", "찾아줘", "뭐야", "무엇", "어디", "어떻게", "관련", "정보", "안내",
@@ -351,7 +373,7 @@ def _metadata_grad_answer(query: str) -> dict | None:
 
 def metadata_direct_answer(query: str) -> dict | None:
     """Answer high-confidence lookup questions without embedding or LLM calls."""
-    for resolver in (_metadata_contact_answer, _metadata_grad_answer):
+    for resolver in (_metadata_doit_answer, _metadata_contact_answer, _metadata_grad_answer):
         answer = resolver(query)
         if answer:
             return answer
@@ -359,6 +381,10 @@ def metadata_direct_answer(query: str) -> dict | None:
 
 def confident_search_answer(query: str, top_k: int = 3) -> dict | None:
     """Return a compact source-grounded answer when retrieval confidence is strong enough."""
+    direct = _metadata_doit_answer(query)
+    if direct:
+        return direct
+
     hits = hybrid_search(query, top_k=max(top_k, 3))
     if hits.empty or "score" not in hits.columns:
         return None
@@ -472,6 +498,8 @@ def _minmax(x):
 # 최신성 점수 함수 제거됨 (학교 기본 정보만 제공)
 
 def hybrid_search(query, top_k=8, alpha=DEFAULT_DENSE_WEIGHT, contact_boost=CONTACT_DOC_BOOST):
+    query = _normalize_doit_query(query)
+
     qv = embed_query(query)
     dense_raw = embeddings @ qv
     bm25_raw  = bm25.get_scores(tokenize_kor(query))
@@ -520,6 +548,10 @@ def hybrid_search(query, top_k=8, alpha=DEFAULT_DENSE_WEIGHT, contact_boost=CONT
     return out.reset_index(drop=True)
 
 def build_answer(query, top_k=6):
+    direct = _metadata_doit_answer(query)
+    if direct:
+        return direct
+
     contact_like = any(k in query for k in CONTACT_KWS)
 
     if contact_like:

--- a/tests/regression/chatbot/check_query_index_metadata_quality.py
+++ b/tests/regression/chatbot/check_query_index_metadata_quality.py
@@ -188,6 +188,32 @@ def make_metadata_rich_df() -> pd.DataFrame:
             "phone": "",
             "email": "",
         },
+        {
+            "doc_id": 6,
+            "chunk_id": "6-0",
+            "parent_id": 6,
+            "title": "주요 서비스",
+            "url": "https://doit.dongyang.ac.kr/main/Login.aspx",
+            "source": "main",
+            "text": "주요 서비스 학생종합관리 DOIT 학생종합관리시스템(DOIT)",
+            "text_for_embedding": "주요 서비스 학생종합관리 DOIT",
+            "text_for_bm25": "주요 서비스 학생종합관리 DOIT 학생종합관리시스템",
+            "text_for_answer": "학생종합관리시스템(DOIT) 안내입니다.",
+            "doc_type": "page",
+            "chunk_type": "page",
+            "breadcrumb": "공통/주요 서비스",
+            "leaf_title": "주요 서비스",
+            "section_title": "주요 서비스",
+            "has_phone": False,
+            "has_email": False,
+            "has_date": False,
+            "has_credit": False,
+            "has_policy_keyword": False,
+            "is_privacy_old": False,
+            "unit": "",
+            "phone": "",
+            "email": "",
+        },
     ]
     return pd.DataFrame(rows)
 
@@ -345,6 +371,44 @@ def run_quality_checks() -> tuple[list[dict], list[str]]:
                         "sparse_top_url": sparse_hits.iloc[0]["url"] if not sparse_hits.empty else "",
                     }
                 )
+
+            spaced_answer = rich_index.build_answer("do it 이 뭐야?", top_k=5)
+            if "학생종합관리시스템" not in (spaced_answer or {}).get("answer", ""):
+                errors.append("spaced_do_it_answer_missing_system")
+            if (spaced_answer or {}).get("url") != "https://doit.dongyang.ac.kr/main/Login.aspx":
+                errors.append(f"spaced_do_it_url_unexpected:{(spaced_answer or {}).get('url')}")
+
+            direct_answer = rich_index.metadata_direct_answer("do it이 뭐야?")
+            if "학생종합관리시스템" not in (direct_answer or {}).get("answer", ""):
+                errors.append("spaced_do_it_direct_answer_missing_system")
+
+            compact_hits = rich_index.hybrid_search("DOIT 이 뭐야?", top_k=5, alpha=0.0)
+            compact_rank = rank_for_url(compact_hits, "https://doit.dongyang.ac.kr/main/Login.aspx")
+            if compact_rank != 1:
+                errors.append(f"compact_doit_expected_not_top:{compact_rank}")
+
+            results.append(
+                {
+                    "id": "spaced_do_it_noise",
+                    "query": "do it 이 뭐야?",
+                    "expected_url": "https://doit.dongyang.ac.kr/main/Login.aspx",
+                    "rich_rank": None,
+                    "sparse_rank": None,
+                    "rich_top_url": (spaced_answer or {}).get("url", ""),
+                    "sparse_top_url": "",
+                }
+            )
+            results.append(
+                {
+                    "id": "compact_doit_system",
+                    "query": "DOIT 이 뭐야?",
+                    "expected_url": "https://doit.dongyang.ac.kr/main/Login.aspx",
+                    "rich_rank": compact_rank,
+                    "sparse_rank": None,
+                    "rich_top_url": compact_hits.iloc[0]["url"] if not compact_hits.empty else "",
+                    "sparse_top_url": "",
+                }
+            )
     finally:
         for name, module in old_modules.items():
             if module is None:

--- a/tests/regression/chatbot/check_query_index_metadata_quality.py
+++ b/tests/regression/chatbot/check_query_index_metadata_quality.py
@@ -16,6 +16,7 @@ ROOT_DIR = Path(__file__).resolve().parents[3]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 DEFAULT_REPORT_PATH = ROOT_DIR / "tests" / "reports" / "chatbot" / "query_index_metadata_quality_report.json"
+DOIT_URL = "https://doit.dongyang.ac.kr/main/Login.aspx"
 
 
 def install_fake_sentence_transformer() -> None:
@@ -193,7 +194,7 @@ def make_metadata_rich_df() -> pd.DataFrame:
             "chunk_id": "6-0",
             "parent_id": 6,
             "title": "주요 서비스",
-            "url": "https://doit.dongyang.ac.kr/main/Login.aspx",
+            "url": DOIT_URL,
             "source": "main",
             "text": "주요 서비스 학생종합관리 DOIT 학생종합관리시스템(DOIT)",
             "text_for_embedding": "주요 서비스 학생종합관리 DOIT",
@@ -375,38 +376,48 @@ def run_quality_checks() -> tuple[list[dict], list[str]]:
             spaced_answer = rich_index.build_answer("do it 이 뭐야?", top_k=5)
             if "학생종합관리시스템" not in (spaced_answer or {}).get("answer", ""):
                 errors.append("spaced_do_it_answer_missing_system")
-            if (spaced_answer or {}).get("url") != "https://doit.dongyang.ac.kr/main/Login.aspx":
+            if (spaced_answer or {}).get("url") != DOIT_URL:
                 errors.append(f"spaced_do_it_url_unexpected:{(spaced_answer or {}).get('url')}")
 
             direct_answer = rich_index.metadata_direct_answer("do it이 뭐야?")
             if "학생종합관리시스템" not in (direct_answer or {}).get("answer", ""):
                 errors.append("spaced_do_it_direct_answer_missing_system")
 
+            for noise_query in ("just do it!", "how do it work?", "can you do it?", "어떻게 do it?"):
+                noise_answer = rich_index.metadata_direct_answer(noise_query)
+                if noise_answer:
+                    errors.append(f"spaced_do_it_false_positive:{noise_query}")
+
             compact_hits = rich_index.hybrid_search("DOIT 이 뭐야?", top_k=5, alpha=0.0)
-            compact_rank = rank_for_url(compact_hits, "https://doit.dongyang.ac.kr/main/Login.aspx")
+            compact_rank = rank_for_url(compact_hits, DOIT_URL)
             if compact_rank != 1:
                 errors.append(f"compact_doit_expected_not_top:{compact_rank}")
+
+            sparse_compact_hits = sparse_index.hybrid_search("DOIT 이 뭐야?", top_k=5, alpha=0.0)
+            sparse_compact_rank = rank_for_url(sparse_compact_hits, DOIT_URL)
+            if sparse_compact_rank != 1:
+                errors.append(f"compact_doit_sparse_expected_not_top:{sparse_compact_rank}")
 
             results.append(
                 {
                     "id": "spaced_do_it_noise",
                     "query": "do it 이 뭐야?",
-                    "expected_url": "https://doit.dongyang.ac.kr/main/Login.aspx",
+                    "expected_url": DOIT_URL,
                     "rich_rank": None,
                     "sparse_rank": None,
                     "rich_top_url": (spaced_answer or {}).get("url", ""),
-                    "sparse_top_url": "",
+                    "sparse_top_url": (spaced_answer or {}).get("url", ""),
                 }
             )
             results.append(
                 {
                     "id": "compact_doit_system",
                     "query": "DOIT 이 뭐야?",
-                    "expected_url": "https://doit.dongyang.ac.kr/main/Login.aspx",
+                    "expected_url": DOIT_URL,
                     "rich_rank": compact_rank,
-                    "sparse_rank": None,
+                    "sparse_rank": sparse_compact_rank,
                     "rich_top_url": compact_hits.iloc[0]["url"] if not compact_hits.empty else "",
-                    "sparse_top_url": "",
+                    "sparse_top_url": sparse_compact_hits.iloc[0]["url"] if not sparse_compact_hits.empty else "",
                 }
             )
     finally:


### PR DESCRIPTION
## 🎯 배경

- 사용자가 `do it이 뭐야?`처럼 띄어쓴 형태로 질문해도 학교 시스템명 `DOIT`를 의도한 질의로 처리해야 합니다.
- 기존 RAG 검색에서는 학과 페이지 공통 “주요 서비스” 블록이나 현장실습 문서로 출처가 흔들릴 수 있었습니다.

## 🔍 주요 내용

- `do it` / `DOIT` 질의를 학생종합관리시스템(DOIT) 직접 답변으로 처리하도록 추가
- DOIT 접속 URL을 함께 반환하도록 `metadata_direct_answer`, `confident_search_answer`, `build_answer` 경로 보강
- `do it이 뭐야?`, `do it 이 뭐야?`, `DOIT 이 뭐야?` 회귀 케이스 추가
- RAG retrieval 평가 리포트 생성: `tests/reports/chatbot/rag_eval_do_it_review.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 변경 요약(1~3줄)  
사용자가 띄어쓴 "do it" 질의를 학교 시스템명 DOIT으로 인식해 직접 답변하도록 하고, RAG 검색의 출처 불안정 문제를 완화하기 위해 쿼리 정규화·메타데이터 직접응답 경로 보강 및 회귀 테스트를 추가했습니다.

## 주요 변경점(3~7개)
- 정규식·상수 추가: SPACED_DO_IT_RE, COMPACT_DOIT_RE 및 DOIT_URL 추가
- DOIT 직접답변 로직 도입: _looks_like_doit_query, _normalize_doit_query, _metadata_doit_answer, _doit_direct_answer 추가
- 처리 체인 보강: metadata_direct_answer, confident_search_answer, build_answer에서 DOIT 직접응답 우선 처리
- 검색 정규화: hybrid_search 호출 전 _normalize_doit_query 적용으로 BM25/임베딩 품질 개선
- 테스트/리포트 추가: 회귀 테스트(띄어쓰기·대소문자 케이스 3개)와 RAG 평가 리포트 tests/reports/chatbot/rag_eval_do_it_review.json 추가
- 테스트 데이터 확장: tests에 DOIT_URL 포함 메타데이터(doc_id=6) 추가

## 주의/리스크(1~3개)
- 정규식 오탐(Critical): SPACED_DO_IT_RE가 일반 영어 문장("just do it")에 매칭되어 잘못된 직접응답을 유발할 수 있음(우선 수정 필요)
- 중복된 호출 부담: DOIT 판정 로직이 metadata_direct_answer, confident_search_answer, build_answer에 중복 등록되어 유지보수성 저하
- 테스트 하드코딩/결과 표기: 테스트에서 DOIT_URL 상수 재사용 미흡 및 sparse_top_url 빈값 등 설명 필요

## 다음 액션(1~3개)
- SPACED_DO_IT_RE 개선(한글 문맥 검사 또는 경계 강화)으로 오탐 차단
- DOIT 판정 로직 중앙화(헬퍼 함수 재사용)로 중복 제거
- 테스트에서 DOIT_URL 상수 재사용 및 sparse_top_url 의도 문서화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->