### PR TITLE
[REFACTOR] OSS 챗봇 서비스 책임 분리

### DIFF
--- a/LLM/OSS/Open_AI_OSS.py
+++ b/LLM/OSS/Open_AI_OSS.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends
 
 from core.auth import verify_jwt_token
-from LLM.OSS.service import ChatReq, chat_with_oss, init_db_pool, shutdown_db_pool
+from LLM.OSS.service import ChatReq, chat_with_oss
 
 
 router = APIRouter()

--- a/LLM/OSS/chat_log_store.py
+++ b/LLM/OSS/chat_log_store.py
@@ -95,10 +95,14 @@ def init_db_pool() -> None:
 
 
 def shutdown_db_pool() -> None:
+    global _db_pool, _ssh_tunnel
+    _log_executor.shutdown(wait=True)
     if _db_pool:
         _db_pool.closeall()
+        _db_pool = None
     if _ssh_tunnel:
         _ssh_tunnel.stop()
+        _ssh_tunnel = None
     logger.info("chatbot_db_pool_shutdown")
 
 

--- a/LLM/OSS/chat_log_store.py
+++ b/LLM/OSS/chat_log_store.py
@@ -1,0 +1,142 @@
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Optional
+
+from psycopg2 import pool as pg_pool
+from sshtunnel import SSHTunnelForwarder
+
+from core.exceptions import ConfigurationError
+from core.logging import get_logger
+from core.settings import get_settings
+
+
+settings = get_settings()
+logger = get_logger(__name__)
+
+_ssh_tunnel: Optional[SSHTunnelForwarder] = None
+_db_pool: Optional[pg_pool.ThreadedConnectionPool] = None
+_log_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="chatbot_log")
+
+
+def init_db_pool() -> None:
+    global _ssh_tunnel, _db_pool
+    ssh_host = settings.ssh_host
+    db_kwargs = dict(
+        dbname=settings.db_name,
+        user=settings.db_user,
+        password=settings.db_password,
+        connect_timeout=3,
+        options="-c statement_timeout=5000",
+    )
+    connection_errors: list[Exception] = []
+    if ssh_host:
+        try:
+            if not settings.ssh_user:
+                raise ConfigurationError("SSH_USER is required when SSH_HOST is set")
+            if not settings.ssh_key_path:
+                raise ConfigurationError("SSH_KEY_PATH is required when SSH_HOST is set")
+            ssh_key_path = Path(settings.ssh_key_path).expanduser()
+            if not ssh_key_path.exists():
+                raise ConfigurationError(f"SSH key file does not exist: {ssh_key_path}")
+            _ssh_tunnel = SSHTunnelForwarder(
+                (ssh_host, 22),
+                ssh_username=settings.ssh_user,
+                ssh_pkey=str(ssh_key_path),
+                remote_bind_address=(settings.ssh_db_host, settings.ssh_db_port),
+            )
+            _ssh_tunnel.start()
+            tunnel_db_kwargs = dict(db_kwargs, host="localhost", port=_ssh_tunnel.local_bind_port)
+            _db_pool = pg_pool.ThreadedConnectionPool(minconn=1, maxconn=5, **tunnel_db_kwargs)
+            logger.info(
+                "chatbot_db_pool_initialized ssh_tunnel=%s db_host=%s db_port=%s",
+                True,
+                tunnel_db_kwargs["host"],
+                tunnel_db_kwargs["port"],
+            )
+            return
+        except ConfigurationError as exc:
+            connection_errors.append(exc)
+            if settings.db_host is None:
+                raise
+            logger.warning("chatbot_ssh_db_config_invalid fallback_to_direct=true error=%s", exc)
+        except Exception as exc:
+            connection_errors.append(exc)
+            if _ssh_tunnel:
+                _ssh_tunnel.stop()
+                _ssh_tunnel = None
+            if settings.db_host is None:
+                raise ConfigurationError(f"SSH database connection failed: {exc}") from exc
+            logger.warning("chatbot_ssh_db_connect_failed fallback_to_direct=true error=%s", exc)
+
+    hosts = (settings.db_host,) if settings.db_host else ("localhost",)
+    for host in hosts:
+        if not host:
+            continue
+        direct_db_kwargs = dict(db_kwargs, host=host, port=settings.db_port)
+        try:
+            _db_pool = pg_pool.ThreadedConnectionPool(minconn=1, maxconn=5, **direct_db_kwargs)
+            logger.info(
+                "chatbot_db_pool_initialized ssh_tunnel=%s db_host=%s db_port=%s",
+                False,
+                direct_db_kwargs["host"],
+                direct_db_kwargs["port"],
+            )
+            return
+        except Exception as exc:
+            connection_errors.append(exc)
+            logger.warning(
+                "chatbot_direct_db_connect_failed db_host=%s db_port=%s error=%s",
+                host,
+                settings.db_port,
+                exc,
+            )
+
+    raise ConfigurationError(f"Database connection failed: {connection_errors[-1]}")
+
+
+def shutdown_db_pool() -> None:
+    if _db_pool:
+        _db_pool.closeall()
+    if _ssh_tunnel:
+        _ssh_tunnel.stop()
+    logger.info("chatbot_db_pool_shutdown")
+
+
+def _write_chatbot_log(
+    query: str,
+    mode: str,
+    response: str,
+    url: Optional[str],
+    cache_hit: bool,
+    latency_ms: int,
+) -> None:
+    if _db_pool is None:
+        return
+    conn = None
+    try:
+        conn = _db_pool.getconn()
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO chatbot_logs (query, mode, response, url, cache_hit, latency_ms)
+                    VALUES (%s, %s, %s, %s, %s, %s)
+                    """,
+                    (query, mode, response, url, cache_hit, latency_ms),
+                )
+    except Exception as exc:
+        logger.warning("chatbot_log_write_failed: %s", exc, exc_info=True)
+    finally:
+        if conn and _db_pool:
+            _db_pool.putconn(conn)
+
+
+def log_chatbot(
+    query: str,
+    mode: str,
+    response: str,
+    url: Optional[str],
+    cache_hit: bool,
+    latency_ms: int,
+) -> None:
+    _log_executor.submit(_write_chatbot_log, query, mode, response, url, cache_hit, latency_ms)

--- a/LLM/OSS/lifecycle.py
+++ b/LLM/OSS/lifecycle.py
@@ -1,0 +1,36 @@
+import asyncio
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from core.exceptions import ConfigurationError
+from core.logging import get_logger
+from core.settings import get_settings
+from LLM.OSS.chat_log_store import init_db_pool, shutdown_db_pool
+from LLM.rule_book.index import build_index
+
+
+settings = get_settings()
+logger = get_logger(__name__)
+
+
+async def startup_chatbot_runtime() -> None:
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, build_index)
+    try:
+        await loop.run_in_executor(None, init_db_pool)
+    except ConfigurationError:
+        if settings.chatbot_log_db_required:
+            raise
+        logger.warning("chatbot_log_db_unavailable startup_continues=true", exc_info=True)
+
+
+def shutdown_chatbot_runtime() -> None:
+    shutdown_db_pool()
+
+
+@asynccontextmanager
+async def chatbot_lifespan(app: FastAPI):
+    await startup_chatbot_runtime()
+    yield
+    shutdown_chatbot_runtime()

--- a/LLM/OSS/llm_client.py
+++ b/LLM/OSS/llm_client.py
@@ -1,0 +1,71 @@
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
+from typing import Optional
+
+from openai import OpenAI
+
+from core.exceptions import ConfigurationError
+from core.logging import get_logger
+from core.settings import get_settings
+
+
+settings = get_settings()
+logger = get_logger(__name__)
+
+_oss_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="chatbot_oss")
+_client: Optional[OpenAI] = None
+_client_lock = threading.Lock()
+
+
+def _get_oss_client() -> OpenAI:
+    global _client
+    if _client is not None:
+        return _client
+
+    with _client_lock:
+        if _client is None:
+            if not settings.oss_api_key or not settings.oss_model:
+                raise ConfigurationError("OSS_API_KEY and OSS_MODEL are required")
+            client_kwargs = {"api_key": settings.oss_api_key}
+            if settings.oss_base_url:
+                client_kwargs["base_url"] = settings.oss_base_url
+            _client = OpenAI(**client_kwargs)
+            logger.info("oss_client_initialized base_url=%s", bool(settings.oss_base_url))
+    return _client
+
+
+def call_oss(messages: list[dict[str, str]], **kwargs) -> str:
+    if not any(message.get("role") == "system" for message in messages):
+        messages = [{
+            "role": "system",
+            "content": (
+                "Reasoning: low\n한국어로 단 한 문장으로만 답하라.\n"
+                "연락처/전화/번호/문의 요청이 없는 한 전화번호나 이메일, URL을 임의로 만들지 말고 포함하지 마라.\n"
+                "모르면 모른다고 답하라."
+            ),
+        }] + messages
+
+    try:
+        client = _get_oss_client()
+    except ConfigurationError:
+        raise
+
+    try:
+        response = client.chat.completions.create(
+            model=settings.oss_model,
+            messages=messages,
+            temperature=kwargs.get("temperature", 0.3),
+            max_tokens=kwargs.get("max_tokens", 64),
+            timeout=kwargs.get("timeout", 45),
+        )
+        return (response.choices[0].message.content or "").strip()
+    except Exception:
+        logger.warning("oss_call_failed", exc_info=True)
+        return ""
+
+
+async def call_oss_async(messages: list[dict[str, str]], **kwargs) -> str:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_oss_executor, partial(call_oss, messages, **kwargs))

--- a/LLM/OSS/llm_client.py
+++ b/LLM/OSS/llm_client.py
@@ -60,6 +60,9 @@ def call_oss(messages: list[dict[str, str]], **kwargs) -> str:
             max_tokens=kwargs.get("max_tokens", 64),
             timeout=kwargs.get("timeout", 45),
         )
+        if not response.choices:
+            logger.warning("oss_call_empty_choices")
+            return ""
         return (response.choices[0].message.content or "").strip()
     except Exception:
         logger.warning("oss_call_failed", exc_info=True)

--- a/LLM/OSS/service.py
+++ b/LLM/OSS/service.py
@@ -2,19 +2,15 @@ import datetime as dt
 import hashlib
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
-from pathlib import Path
 from typing import Optional
 
 import httpx
 from cachetools import TTLCache
-from psycopg2 import pool as pg_pool
 from pydantic import BaseModel
-from sshtunnel import SSHTunnelForwarder
 
-from core.exceptions import ConfigurationError
 from core.logging import get_logger
 from core.settings import get_settings
+from LLM.OSS.chat_log_store import init_db_pool, log_chatbot, shutdown_db_pool
 from LLM.OSS.formatter import (
     scrub_non_contact,
 )
@@ -47,10 +43,6 @@ _CACHE_GENERAL: TTLCache = TTLCache(maxsize=500, ttl=3600)
 _CACHE_SKIP = frozenset({"oss", "greet", "whoami", "relation", "guard"})
 _cache_lock = threading.Lock()
 
-_ssh_tunnel: Optional[SSHTunnelForwarder] = None
-_db_pool: Optional[pg_pool.ThreadedConnectionPool] = None
-_log_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="chatbot_log")
-
 PROFANITY_GUARD_TEXT = "부적절한 표현이 포함되어 답변하기 어려워요. 질문을 순화해서 다시 입력해 주세요."
 
 
@@ -58,112 +50,6 @@ class ChatReq(BaseModel):
     text: Optional[str] = None
     messages: Optional[list[dict[str, str]]] = None
     engine: Optional[str] = None
-
-
-def init_db_pool() -> None:
-    global _ssh_tunnel, _db_pool
-    ssh_host = settings.ssh_host
-    db_kwargs = dict(
-        dbname=settings.db_name,
-        user=settings.db_user,
-        password=settings.db_password,
-        connect_timeout=3,
-        options="-c statement_timeout=5000",
-    )
-    connection_errors: list[Exception] = []
-    if ssh_host:
-        try:
-            if not settings.ssh_user:
-                raise ConfigurationError("SSH_USER is required when SSH_HOST is set")
-            if not settings.ssh_key_path:
-                raise ConfigurationError("SSH_KEY_PATH is required when SSH_HOST is set")
-            ssh_key_path = Path(settings.ssh_key_path).expanduser()
-            if not ssh_key_path.exists():
-                raise ConfigurationError(f"SSH key file does not exist: {ssh_key_path}")
-            _ssh_tunnel = SSHTunnelForwarder(
-                (ssh_host, 22),
-                ssh_username=settings.ssh_user,
-                ssh_pkey=str(ssh_key_path),
-                remote_bind_address=(settings.ssh_db_host, settings.ssh_db_port),
-            )
-            _ssh_tunnel.start()
-            tunnel_db_kwargs = dict(db_kwargs, host="localhost", port=_ssh_tunnel.local_bind_port)
-            _db_pool = pg_pool.ThreadedConnectionPool(minconn=1, maxconn=5, **tunnel_db_kwargs)
-            logger.info(
-                "chatbot_db_pool_initialized ssh_tunnel=%s db_host=%s db_port=%s",
-                True,
-                tunnel_db_kwargs["host"],
-                tunnel_db_kwargs["port"],
-            )
-            return
-        except ConfigurationError as exc:
-            connection_errors.append(exc)
-            if settings.db_host is None:
-                raise
-            logger.warning("chatbot_ssh_db_config_invalid fallback_to_direct=true error=%s", exc)
-        except Exception as exc:
-            connection_errors.append(exc)
-            if _ssh_tunnel:
-                _ssh_tunnel.stop()
-                _ssh_tunnel = None
-            if settings.db_host is None:
-                raise ConfigurationError(f"SSH database connection failed: {exc}") from exc
-            logger.warning("chatbot_ssh_db_connect_failed fallback_to_direct=true error=%s", exc)
-
-    hosts = (settings.db_host, ) if settings.db_host else ("localhost",)
-    for host in hosts:
-        if not host:
-            continue
-        direct_db_kwargs = dict(db_kwargs, host=host, port=settings.db_port)
-        try:
-            _db_pool = pg_pool.ThreadedConnectionPool(minconn=1, maxconn=5, **direct_db_kwargs)
-            logger.info(
-                "chatbot_db_pool_initialized ssh_tunnel=%s db_host=%s db_port=%s",
-                False,
-                direct_db_kwargs["host"],
-                direct_db_kwargs["port"],
-            )
-            return
-        except Exception as exc:
-            connection_errors.append(exc)
-            logger.warning(
-                "chatbot_direct_db_connect_failed db_host=%s db_port=%s error=%s",
-                host,
-                settings.db_port,
-                exc,
-            )
-
-    raise ConfigurationError(f"Database connection failed: {connection_errors[-1]}")
-
-
-def shutdown_db_pool() -> None:
-    if _db_pool:
-        _db_pool.closeall()
-    if _ssh_tunnel:
-        _ssh_tunnel.stop()
-    logger.info("chatbot_db_pool_shutdown")
-
-
-def _log_chatbot(query: str, mode: str, response: str, url: Optional[str], cache_hit: bool, latency_ms: int) -> None:
-    if _db_pool is None:
-        return
-    conn = None
-    try:
-        conn = _db_pool.getconn()
-        with conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    INSERT INTO chatbot_logs (query, mode, response, url, cache_hit, latency_ms)
-                    VALUES (%s, %s, %s, %s, %s, %s)
-                    """,
-                    (query, mode, response, url, cache_hit, latency_ms),
-                )
-    except Exception as exc:
-        logger.warning("chatbot_log_write_failed: %s", exc, exc_info=True)
-    finally:
-        if conn and _db_pool:
-            _db_pool.putconn(conn)
 
 
 def _log_tool_route(user_text: str, mode: str, stage: str, result: ToolResult) -> None:
@@ -239,7 +125,7 @@ async def chat_with_oss(req: ChatReq) -> dict:
 
     if await should_block_profanity(user_text):
         latency = int((time.monotonic() - start) * 1000)
-        _log_executor.submit(_log_chatbot, user_text, "guard", PROFANITY_GUARD_TEXT, None, False, latency)
+        log_chatbot(user_text, "guard", PROFANITY_GUARD_TEXT, None, False, latency)
         return {"engine": "guard", "text": PROFANITY_GUARD_TEXT}
 
     if GOVERNANCE_REMOVE_RE.search(user_text) and GOVERNANCE_TARGET_RE.search(user_text):
@@ -264,7 +150,7 @@ async def chat_with_oss(req: ChatReq) -> dict:
         if cached is not None:
             latency = int((time.monotonic() - start) * 1000)
             response = dict(cached)
-            _log_executor.submit(_log_chatbot, user_text, mode, response.get("text", ""), response.get("url"), True, latency)
+            log_chatbot(user_text, mode, response.get("text", ""), response.get("url"), True, latency)
             return response
 
     def cache_and_return(response: dict) -> dict:
@@ -273,7 +159,7 @@ async def chat_with_oss(req: ChatReq) -> dict:
             with _cache_lock:
                 cache[cache_key] = response
         latency = int((time.monotonic() - start) * 1000)
-        _log_executor.submit(_log_chatbot, user_text, mode, response.get("text", ""), response.get("url"), False, latency)
+        log_chatbot(user_text, mode, response.get("text", ""), response.get("url"), False, latency)
         return response
 
     if mode == "rule_book":
@@ -323,7 +209,7 @@ async def chat_with_oss(req: ChatReq) -> dict:
                 output = scrub_non_contact(output)
             if output:
                 latency = int((time.monotonic() - start) * 1000)
-                _log_executor.submit(_log_chatbot, user_text, "oss", output, None, False, latency)
+                log_chatbot(user_text, "oss", output, None, False, latency)
                 return {"engine": "oss", "text": output}
 
             fallback = run_empty_oss_fallback_tools(user_text)
@@ -331,13 +217,13 @@ async def chat_with_oss(req: ChatReq) -> dict:
             if fallback.handled:
                 response = fallback.to_response()
                 latency = int((time.monotonic() - start) * 1000)
-                _log_executor.submit(_log_chatbot, user_text, response["engine"], response["text"], response.get("url"), False, latency)
+                log_chatbot(user_text, response["engine"], response["text"], response.get("url"), False, latency)
                 return response
 
             if len(user_text) <= 2 or GREETING_RE.search(user_text):
                 latency = int((time.monotonic() - start) * 1000)
                 output = "안녕하세요, 무엇을 도와드릴까요?"
-                _log_executor.submit(_log_chatbot, user_text, "greet", output, None, False, latency)
+                log_chatbot(user_text, "greet", output, None, False, latency)
                 return {"engine": "greet", "text": output}
 
             return cache_and_return({
@@ -355,7 +241,7 @@ async def chat_with_oss(req: ChatReq) -> dict:
             if fallback.handled:
                 response = fallback.to_response()
                 latency = int((time.monotonic() - start) * 1000)
-                _log_executor.submit(_log_chatbot, user_text, response["engine"], response["text"], response.get("url"), False, latency)
+                log_chatbot(user_text, response["engine"], response["text"], response.get("url"), False, latency)
                 return response
 
             if len(user_text) <= 2 or GREETING_RE.search(user_text):
@@ -363,7 +249,7 @@ async def chat_with_oss(req: ChatReq) -> dict:
 
         if output:
             latency = int((time.monotonic() - start) * 1000)
-            _log_executor.submit(_log_chatbot, user_text, "oss", output, None, False, latency)
+            log_chatbot(user_text, "oss", output, None, False, latency)
             return {"engine": "oss", "text": output}
         
         if grounded_fallback is not None and not grounded_fallback.text.strip():
@@ -394,5 +280,5 @@ async def chat_with_oss(req: ChatReq) -> dict:
         fused = text if looks_like_topic(user_text) else "좋아요, 무엇을 이야기해 볼까요?"
 
     latency = int((time.monotonic() - start) * 1000)
-    _log_executor.submit(_log_chatbot, user_text, mode, fused, None, False, latency)
+    log_chatbot(user_text, mode, fused, None, False, latency)
     return {"engine": mode, "text": fused}

--- a/LLM/OSS/service.py
+++ b/LLM/OSS/service.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 
 from core.logging import get_logger
 from core.settings import get_settings
-from LLM.OSS.chat_log_store import init_db_pool, log_chatbot, shutdown_db_pool
+from LLM.OSS.chat_log_store import log_chatbot
 from LLM.OSS.formatter import (
     scrub_non_contact,
 )

--- a/LLM/OSS/service.py
+++ b/LLM/OSS/service.py
@@ -1,16 +1,13 @@
 import datetime as dt
-import asyncio
 import hashlib
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from functools import partial
 from pathlib import Path
 from typing import Optional
 
 import httpx
 from cachetools import TTLCache
-from openai import OpenAI
 from psycopg2 import pool as pg_pool
 from pydantic import BaseModel
 from sshtunnel import SSHTunnelForwarder
@@ -21,6 +18,7 @@ from core.settings import get_settings
 from LLM.OSS.formatter import (
     scrub_non_contact,
 )
+from LLM.OSS.llm_client import call_oss_async
 from LLM.OSS.modes import (
     COUNCIL_KWS,
     GOVERNANCE_REMOVE_RE,
@@ -52,10 +50,6 @@ _cache_lock = threading.Lock()
 _ssh_tunnel: Optional[SSHTunnelForwarder] = None
 _db_pool: Optional[pg_pool.ThreadedConnectionPool] = None
 _log_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="chatbot_log")
-_oss_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="chatbot_oss")
-
-_client: Optional[OpenAI] = None
-_client_lock = threading.Lock()
 
 PROFANITY_GUARD_TEXT = "부적절한 표현이 포함되어 답변하기 어려워요. 질문을 순화해서 다시 입력해 주세요."
 
@@ -187,56 +181,6 @@ def _log_tool_route(user_text: str, mode: str, stage: str, result: ToolResult) -
         bool(result.text.strip()),
         result.reason,
     )
-
-
-def _get_oss_client() -> OpenAI:
-    global _client
-    if _client is not None:
-        return _client
-
-    with _client_lock:
-        if _client is None:
-            if not settings.oss_api_key or not settings.oss_model:
-                raise ConfigurationError("OSS_API_KEY and OSS_MODEL are required")
-            client_kwargs = {"api_key": settings.oss_api_key}
-            if settings.oss_base_url:
-                client_kwargs["base_url"] = settings.oss_base_url
-            _client = OpenAI(**client_kwargs)
-            logger.info("oss_client_initialized base_url=%s", bool(settings.oss_base_url))
-    return _client
-
-
-def call_oss(messages: list[dict[str, str]], **kwargs) -> str:
-    if not any(message.get("role") == "system" for message in messages):
-        messages = [{
-            "role": "system",
-            "content": (
-                "Reasoning: low\n한국어로 단 한 문장으로만 답하라.\n"
-                "연락처/전화/번호/문의 요청이 없는 한 전화번호나 이메일, URL을 임의로 만들지 말고 포함하지 마라.\n"
-                "모르면 모른다고 답하라."
-            ),
-        }] + messages
-    try:
-        client = _get_oss_client()
-    except ConfigurationError:
-        raise
-    try:
-        response = _get_oss_client().chat.completions.create(
-            model=settings.oss_model,
-            messages=messages,
-            temperature=kwargs.get("temperature", 0.3),
-            max_tokens=kwargs.get("max_tokens", 64),
-            timeout=kwargs.get("timeout", 45),
-        )
-        return (response.choices[0].message.content or "").strip()
-    except Exception:
-        logger.warning("oss_call_failed", exc_info=True)
-        return ""
-
-
-async def call_oss_async(messages: list[dict[str, str]], **kwargs) -> str:
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(_oss_executor, partial(call_oss, messages, **kwargs))
 
 
 async def should_block_profanity(user_text: str) -> bool:

--- a/app_oss_main.py
+++ b/app_oss_main.py
@@ -1,5 +1,3 @@
-from contextlib import asynccontextmanager
-import asyncio
 from fastapi import FastAPI
 
 from core.exceptions import register_exception_handlers
@@ -7,19 +5,11 @@ from core.logging import configure_logging, register_request_logging
 
 configure_logging("chatbot-api")
 
-from LLM.OSS.Open_AI_OSS import router as Open_AI_OSS, init_db_pool, shutdown_db_pool
-from LLM.rule_book.index import build_index
+from LLM.OSS.Open_AI_OSS import router as Open_AI_OSS
+from LLM.OSS.lifecycle import chatbot_lifespan
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    await asyncio.get_event_loop().run_in_executor(None, build_index)
-    await asyncio.get_event_loop().run_in_executor(None, init_db_pool)
-    yield
-    shutdown_db_pool()
-
-
-app = FastAPI(lifespan=lifespan)
+app = FastAPI(lifespan=chatbot_lifespan)
 register_request_logging(app)
 register_exception_handlers(app)
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -38,6 +38,7 @@ class Settings:
     oss_model: str | None
     json_only_mode: bool
     chatbot_profanity_filter_enabled: bool
+    chatbot_log_db_required: bool
     text_filter_api_url: str | None
     text_filter_api_timeout: float
     root_base_path: str | None
@@ -99,6 +100,7 @@ def get_settings() -> Settings:
         oss_model=os.getenv("OSS_MODEL"),
         json_only_mode=os.getenv("JSON_ONLY_MODE", "0").strip() == "1",
         chatbot_profanity_filter_enabled=os.getenv("CHATBOT_PROFANITY_FILTER_ENABLED", "0").strip() == "1",
+        chatbot_log_db_required=os.getenv("CHATBOT_LOG_DB_REQUIRED", "0").strip() == "1",
         text_filter_api_url=os.getenv("TEXT_FILTER_API_URL"),
         text_filter_api_timeout=_get_float_env("TEXT_FILTER_API_TIMEOUT", 10.0),
         root_base_path=os.getenv("ROOT_BASE_PATH"),

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -105,6 +105,7 @@ User Query → Greeting/Intent Detection → Hybrid Search (BM25 + embeddings)
 | ----------------------------------------- | ----------------------------------------------- |
 | `OSS_BASE_URL`                            | Ollama server URL (`http://localhost:11434/v1`) |
 | `OSS_MODEL`                               | LLM model name (`gpt-oss:20b`)                  |
+| `CHATBOT_LOG_DB_REQUIRED`                 | Fail chatbot startup if log DB is unavailable (`0` by default) |
 | `SECRET_KEY` / `ALGORITHM`                | JWT auth (HS512)                                |
 | `DB_NAME/USER/PASSWORD`                   | PostgreSQL credentials                          |
 | `DATA_JSON`                               | School info corpus path                         |

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -74,6 +74,7 @@
 │   │   ├── Open_AI_OSS.py          # 챗봇 메인 오케스트레이션
 │   │   ├── service.py              # 챗봇 서비스 연결부
 │   │   ├── llm_client.py           # OSS/OpenAI 호환 LLM client 생성 및 호출
+│   │   ├── chat_log_store.py       # 챗봇 DB 로그 저장 및 DB/SSH pool 관리
 │   │   ├── tools.py                # 비용 우선 deterministic tool routing
 │   │   ├── formatter.py            # 응답 포맷팅
 │   │   ├── modes.py                # 챗봇 모드 정의
@@ -150,6 +151,7 @@
 - `LLM/OSS/Open_AI_OSS.py`
 - `LLM/OSS/service.py`
 - `LLM/OSS/llm_client.py`
+- `LLM/OSS/chat_log_store.py`
 - `LLM/OSS/tools.py`
 - `LLM/OSS/formatter.py`
 - `LLM/OSS/modes.py`

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -73,6 +73,7 @@
 │   ├── OSS/
 │   │   ├── Open_AI_OSS.py          # 챗봇 메인 오케스트레이션
 │   │   ├── service.py              # 챗봇 서비스 연결부
+│   │   ├── llm_client.py           # OSS/OpenAI 호환 LLM client 생성 및 호출
 │   │   ├── tools.py                # 비용 우선 deterministic tool routing
 │   │   ├── formatter.py            # 응답 포맷팅
 │   │   ├── modes.py                # 챗봇 모드 정의
@@ -148,6 +149,7 @@
 
 - `LLM/OSS/Open_AI_OSS.py`
 - `LLM/OSS/service.py`
+- `LLM/OSS/llm_client.py`
 - `LLM/OSS/tools.py`
 - `LLM/OSS/formatter.py`
 - `LLM/OSS/modes.py`

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -73,6 +73,7 @@
 │   ├── OSS/
 │   │   ├── Open_AI_OSS.py          # 챗봇 메인 오케스트레이션
 │   │   ├── service.py              # 챗봇 서비스 연결부
+│   │   ├── lifecycle.py            # 챗봇 startup/shutdown 런타임 초기화
 │   │   ├── llm_client.py           # OSS/OpenAI 호환 LLM client 생성 및 호출
 │   │   ├── chat_log_store.py       # 챗봇 DB 로그 저장 및 DB/SSH pool 관리
 │   │   ├── tools.py                # 비용 우선 deterministic tool routing
@@ -150,6 +151,7 @@
 
 - `LLM/OSS/Open_AI_OSS.py`
 - `LLM/OSS/service.py`
+- `LLM/OSS/lifecycle.py`
 - `LLM/OSS/llm_client.py`
 - `LLM/OSS/chat_log_store.py`
 - `LLM/OSS/tools.py`
@@ -222,6 +224,7 @@
 ## 운영상 알아둘 점
 
 - 챗봇은 `OSS_BASE_URL`을 통한 Ollama 호환 API 접근에 의존합니다.
+- 챗봇 로그 DB는 기본적으로 best-effort로 초기화합니다. `CHATBOT_LOG_DB_REQUIRED=1`이면 로그 DB 연결 실패 시 startup을 실패 처리합니다.
 - 시간표 분석은 한국어 지원이 포함된 Tesseract OCR에 의존합니다.
 - 일부 챗봇 인덱싱 유틸은 KoNLPy/JPype1 사용을 위해 Java가 필요합니다.
 - 인증은 `.env`의 JWT 관련 값을 사용합니다.


### PR DESCRIPTION
## 관련 이슈

Closes #127 

## 🎯 배경

OSS 챗봇 서비스의 주요 런타임 책임이 `LLM/OSS/service.py`에 집중되어 있어 유지보수와 테스트가 어려운 상태입니다.

이번 PR에서는 기존 챗봇 응답 흐름과 RAG 동작은 유지하면서, OSS LLM 호출, DB 로그 저장, 챗봇 시작/lifespan 초기화 책임을 단계적으로 분리합니다.

검색 인덱스 로딩/초기화 분리는 RAG 아티팩트와 import 시점 로딩 영향이 커서 별도 브랜치에서 진행합니다.

## 🔍 주요 내용

- OSS/OpenAI 호환 LLM client 생성 및 호출 로직을 `LLM/OSS/llm_client.py`로 분리
- `LLM/OSS/service.py`는 챗봇 요청 흐름 조율에 집중하도록 정리
- OSS client와 `ThreadPoolExecutor`는 모듈 전역으로 유지해 매 요청마다 새로 생성되지 않도록 구성
- 챗봇 서비스 구조 변경 사항을 `docs/PLANS.md`에 반영

## ✅ 체크리스트

- [x] OSS LLM client 생성 및 호출 로직 분리
- [x] DB 로그 저장 로직 분리
- [x] 챗봇 시작/lifespan 초기화 흐름 분리
- [x] 기존 `/chatbot` 응답 포맷 유지 확인
- [x] Python compile 검증
- [x] 필요한 경우 챗봇 회귀 테스트 실행

## 🧪 검증

- [x] `python -m py_compile LLM/OSS/llm_client.py LLM/OSS/service.py LLM/OSS/Open_AI_OSS.py app_oss_main.py`
- [x] `python -m compileall LLM/OSS/service.py LLM/OSS/llm_client.py`
- [x] `python scripts/agent_checks/run_agent_preflight.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 변경 요약
OSS 챗봇 런타임 책임을 분리해 service.py를 경량화했습니다. LLM 호출은 llm_client.py로, 챗봇 로그 저장은 chat_log_store.py로 분리하고 라이프사이클 훅을 lifecycle.py로 이동했습니다.

## 주요 변경점
- LLM/OSS/llm_client.py 추가: OSS(OpenAI 호환) 클라이언트 지연 초기화, 동기 call_oss 및 비동기 call_oss_async 제공.
- LLM/OSS/chat_log_store.py 추가: PostgreSQL 로그 비동기 저장용 DB 풀 init/shutdown 및 log_chatbot(백그라운드 INSERT) 구현, SSH 터널/직접 연결 폴백 지원.
- LLM/OSS/service.py 정리: 클라이언트·DB·executor 전역 상태 및 로컬 호출/로깅 제거, llm_client.call_oss_async와 chat_log_store.log_chatbot로 책임 위임.
- LLM/OSS/lifecycle.py + app_oss_main.py 변경: FastAPI lifespan으로 챗봇 startup/shutdown 로직 이동(인덱스 빌드·DB 초기화 비동기화 및 예외 정책 적용).
- 설정·문서 업데이트: core/settings에 CHATBOT_LOG_DB_REQUIRED 추가 및 docs/PLANS.md, docs/AGENTS.md 갱신.
- 검증: 관련 모듈 컴파일 검사 및 사전 점검 스크립트 실행(회귀 RAG 테스트는 보류).

## 주의/리스크
- DB 풀·SSH 터널·ThreadPoolExecutor 수명 관리(정상 종료·자원 해제) 검증 필요.
- 시스템 프롬프트 자동 주입으로 /chatbot 응답 포맷에 미세한 변화 가능 — 응답 호환성 회귀 권장.
- 검색 인덱스 로딩 분리는 별도 브랜치로 연기되어 관련 런타임 이슈가 남을 수 있음.

## 다음 액션
- /chatbot 응답 포맷 확인 및 RAG 회귀 테스트 실행.
- 운영 환경에서 DB/SSH 풀과 executor의 startup/shutdown 동작 검증 및 문서화.
- 검색 인덱스 로딩·초기화 책임 분리 작업을 별도 브랜치에서 진행.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->