### PR TITLE
refactor: separate chatbot query index loading

### DIFF
--- a/LLM/sub_model/query_index.py
+++ b/LLM/sub_model/query_index.py
@@ -1,6 +1,9 @@
-import os, re, json, pickle, numpy as np, pandas as pd
-from pathlib import Path
+import re
 from functools import lru_cache
+
+import numpy as np
+import pandas as pd
+
 from LLM.patterns import (
     BOARD_URL_PATTERN,
     DASH_CHARS_PATTERN,
@@ -16,17 +19,7 @@ from LLM.patterns import (
     UNIT_QUERY_SUFFIX_PATTERN,
     UNIT_SUFFIX_RE,
 )
-from sentence_transformers import SentenceTransformer
-from rank_bm25 import BM25Okapi
-from LLM.sub_model.index_utils import get_tokenizer, load_json_gz  # 서버용
-from LLM.sub_model.query_index_schema import normalize_search_df_schema
-# from index_utils import get_tokenizer, load_json_gz
-from dotenv import load_dotenv
-
-load_dotenv()
-
-THIS_DIR = Path(__file__).resolve().parent
-ROOT_DIR = THIS_DIR.parent.parent
+from LLM.sub_model.query_index_loader import load_query_index_resources
 
 # 졸업학점 관련 키워드 복원 (학교 기본 정보 포함)
 GRAD_KWS = ["졸업학점", "졸업 학점", "졸업요건", "졸업요구학점", "이수학점", "졸업 이수학점"]
@@ -449,55 +442,25 @@ def _extract_3yr_from_tables(text: str):
             out["major_min"] = {"old": old_v, "new": new_v}
     return out
 
-def env_path(name: str) -> Path:
-    val = os.getenv(name, "").strip()
-    if not val:
-        raise FileNotFoundError(f"{name} environment empty.")
-    s = os.path.expandvars(val)
-    p = Path(s)
-    if not p.is_absolute():
-        p = (ROOT_DIR / p)
-    return p.resolve()
-
-def load_list_from_txt(path: Path) -> list:
-    with open(path, "r", encoding="utf-8") as f:
-        return [line.strip() for line in f if line.strip()]
-
-DATA_JSON        = env_path("DATA_JSON")
-ART_DIR          = env_path("ART_DIR")
-SEARCH_DF_PATH   = env_path("SEARCH_DF_PATH")
-EMB_PATH         = env_path("EMB_PATH")
-BM25_PATH        = env_path("BM25_PATH")
-TOK_PATH         = env_path("TOK_PATH")
-CONTACTS_CSV     = env_path("CONTACTS_CSV")
-META_PATH        = env_path("META_PATH")
-CONTACT_KWS      = load_list_from_txt(env_path("CONTACT_KWS_PATH"))
-
-embeddings = np.load(EMB_PATH, mmap_mode="r").astype(np.float32)
-row_norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
-row_norms[row_norms == 0] = 1.0
-embeddings = embeddings / row_norms
+_index_resources = load_query_index_resources()
+DATA_JSON        = _index_resources.paths.data_json
+ART_DIR          = _index_resources.paths.art_dir
+SEARCH_DF_PATH   = _index_resources.paths.search_df_path
+EMB_PATH         = _index_resources.paths.emb_path
+BM25_PATH        = _index_resources.paths.bm25_path
+TOK_PATH         = _index_resources.paths.tok_path
+CONTACTS_CSV     = _index_resources.paths.contacts_csv
+META_PATH        = _index_resources.paths.meta_path
+CONTACT_KWS      = _index_resources.contact_kws
+embeddings       = _index_resources.embeddings
 
 UNIT_TOK_RE = re.compile(HANGUL_TOKEN_PATTERN)
 
-model_name = "intfloat/multilingual-e5-base"
-model = SentenceTransformer(model_name)
-
-search_df = normalize_search_df_schema(pd.read_parquet(SEARCH_DF_PATH))
-
-tokenize_kor = get_tokenizer()
-
-if BM25_PATH.exists():
-    with open(BM25_PATH, 'rb') as f:
-        bm25 = pickle.load(f)
-else:
-    if TOK_PATH.exists():
-        tokenized_courpus = load_json_gz(str(TOK_PATH))
-    else:
-        tokenized_courpus = [tokenize_kor(t) for t in search_df["text_for_bm25"].astype(str).tolist()]
-    bm25 = BM25Okapi(tokenized_courpus)
-
-
+model_name   = _index_resources.model_name
+model        = _index_resources.model
+search_df    = _index_resources.search_df
+tokenize_kor = _index_resources.tokenizer
+bm25         = _index_resources.bm25
 
 @lru_cache(maxsize=512)
 def embed_query(q: str):

--- a/LLM/sub_model/query_index_loader.py
+++ b/LLM/sub_model/query_index_loader.py
@@ -86,9 +86,6 @@ def load_embeddings(path: Path) -> np.ndarray:
 
 
 def load_bm25(path: Path, tok_path: Path, search_df: pd.DataFrame, tokenizer) -> BM25Okapi:
-    if path.exists():
-        with open(path, "rb") as f:
-            return pickle.load(f)
 
     if tok_path.exists():
         logger.warning(

--- a/LLM/sub_model/query_index_loader.py
+++ b/LLM/sub_model/query_index_loader.py
@@ -1,0 +1,117 @@
+import os
+import pickle
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+import pandas as pd
+from dotenv import load_dotenv
+from rank_bm25 import BM25Okapi
+from sentence_transformers import SentenceTransformer
+
+from LLM.sub_model.index_utils import get_tokenizer, load_json_gz
+from LLM.sub_model.query_index_schema import normalize_search_df_schema
+
+load_dotenv()
+
+THIS_DIR = Path(__file__).resolve().parent
+ROOT_DIR = THIS_DIR.parent.parent
+DEFAULT_MODEL_NAME = "intfloat/multilingual-e5-base"
+
+
+@dataclass(frozen=True)
+class QueryIndexPaths:
+    data_json: Path
+    art_dir: Path
+    search_df_path: Path
+    emb_path: Path
+    bm25_path: Path
+    tok_path: Path
+    contacts_csv: Path
+    meta_path: Path
+    contact_kws_path: Path
+
+
+@dataclass(frozen=True)
+class QueryIndexResources:
+    paths: QueryIndexPaths
+    contact_kws: list[str]
+    embeddings: np.ndarray
+    search_df: pd.DataFrame
+    tokenizer: Callable[[str], list[str]]
+    bm25: BM25Okapi
+    model_name: str
+    model: SentenceTransformer
+
+
+def env_path(name: str) -> Path:
+    val = os.getenv(name, "").strip()
+    if not val:
+        raise FileNotFoundError(f"{name} environment empty.")
+    s = os.path.expandvars(val)
+    p = Path(s)
+    if not p.is_absolute():
+        p = ROOT_DIR / p
+    return p.resolve()
+
+
+def load_list_from_txt(path: Path) -> list[str]:
+    with open(path, "r", encoding="utf-8") as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def load_query_index_paths() -> QueryIndexPaths:
+    return QueryIndexPaths(
+        data_json=env_path("DATA_JSON"),
+        art_dir=env_path("ART_DIR"),
+        search_df_path=env_path("SEARCH_DF_PATH"),
+        emb_path=env_path("EMB_PATH"),
+        bm25_path=env_path("BM25_PATH"),
+        tok_path=env_path("TOK_PATH"),
+        contacts_csv=env_path("CONTACTS_CSV"),
+        meta_path=env_path("META_PATH"),
+        contact_kws_path=env_path("CONTACT_KWS_PATH"),
+    )
+
+
+def load_embeddings(path: Path) -> np.ndarray:
+    embeddings = np.load(path, mmap_mode="r").astype(np.float32)
+    row_norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+    row_norms[row_norms == 0] = 1.0
+    return embeddings / row_norms
+
+
+def load_bm25(path: Path, tok_path: Path, search_df: pd.DataFrame, tokenizer) -> BM25Okapi:
+    if path.exists():
+        with open(path, "rb") as f:
+            return pickle.load(f)
+
+    if tok_path.exists():
+        tokenized_corpus = load_json_gz(str(tok_path))
+    else:
+        tokenized_corpus = [
+            tokenizer(t)
+            for t in search_df["text_for_bm25"].astype(str).tolist()
+        ]
+    return BM25Okapi(tokenized_corpus)
+
+
+def load_query_index_resources(
+    paths: QueryIndexPaths | None = None,
+    model_name: str = DEFAULT_MODEL_NAME,
+) -> QueryIndexResources:
+    paths = paths or load_query_index_paths()
+    search_df = normalize_search_df_schema(pd.read_parquet(paths.search_df_path))
+    tokenizer = get_tokenizer()
+
+    return QueryIndexResources(
+        paths=paths,
+        contact_kws=load_list_from_txt(paths.contact_kws_path),
+        embeddings=load_embeddings(paths.emb_path),
+        search_df=search_df,
+        tokenizer=tokenizer,
+        bm25=load_bm25(paths.bm25_path, paths.tok_path, search_df, tokenizer),
+        model_name=model_name,
+        model=SentenceTransformer(model_name),
+    )

--- a/LLM/sub_model/query_index_loader.py
+++ b/LLM/sub_model/query_index_loader.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pickle
 from dataclasses import dataclass
@@ -14,6 +15,8 @@ from LLM.sub_model.index_utils import get_tokenizer, load_json_gz
 from LLM.sub_model.query_index_schema import normalize_search_df_schema
 
 load_dotenv()
+
+logger = logging.getLogger(__name__)
 
 THIS_DIR = Path(__file__).resolve().parent
 ROOT_DIR = THIS_DIR.parent.parent
@@ -88,8 +91,19 @@ def load_bm25(path: Path, tok_path: Path, search_df: pd.DataFrame, tokenizer) ->
             return pickle.load(f)
 
     if tok_path.exists():
+        logger.warning(
+            "query_index_bm25_pickle_missing fallback=tokenized_corpus bm25_file=%s tokenized_file=%s",
+            path.name,
+            tok_path.name,
+        )
         tokenized_corpus = load_json_gz(str(tok_path))
     else:
+        logger.warning(
+            "query_index_bm25_pickle_missing fallback=runtime_tokenize bm25_file=%s tokenized_file=%s documents=%s",
+            path.name,
+            tok_path.name,
+            len(search_df),
+        )
         tokenized_corpus = [
             tokenizer(t)
             for t in search_df["text_for_bm25"].astype(str).tolist()

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -89,6 +89,7 @@
 │   │       └── __init__.py
 │   ├── sub_model/
 │   │   ├── query_index.py          # 하이브리드 검색
+│   │   ├── query_index_loader.py   # 검색 인덱스 환경 경로 해석 및 아티팩트 로딩
 │   │   ├── schedule_index.py       # 학사일정 인덱싱
 │   │   ├── schedule_rules.py       # 학사일정 태그/검색 키워드 규칙
 │   │   ├── index_utils.py          # 한국어 NLP/청킹 유틸
@@ -177,6 +178,7 @@
 - 문서는 `intro`, `department`, `policy`, `history`, `privacy`, `contact`, `table_like`, `page` 같은 검색용 타입으로 분류합니다.
 - `build_index.py`는 `chunk_document()` 결과를 사용해 `text_for_embedding`, `text_for_bm25`, `text_for_answer`를 분리 저장합니다.
 - `search_df.parquet`에는 `breadcrumb`, `leaf_title`, `section_title`, `has_phone`, `has_date`, `has_credit`, `has_policy_keyword`, `is_privacy_old` 같은 메타데이터를 함께 저장합니다.
+- `query_index_loader.py`는 환경변수 기반 경로 해석, 검색 아티팩트 로딩, BM25 fallback 생성을 담당합니다.
 - `query_index.py`는 기존 `build_answer()` 인터페이스를 유지하되, 새 컬럼이 있으면 메타데이터 기반 가중치와 답변용 본문을 우선 사용하고 구버전 아티팩트에는 `text` 기반으로 fallback 합니다.
 - `model/artifacts/` 아래 파일은 생성 산출물이므로 직접 편집하지 않고 `LLM/sub_model/build_index.py`로 재생성합니다.
 


### PR DESCRIPTION
## 🎯 배경

- 검색 인덱스 로딩/초기화 코드가 `query_index.py` 안에 함께 있어 검색 로직과 런타임 리소스 준비 책임이 섞여 있었습니다.
- RAG 검색 로직은 유지하면서 환경변수 경로 해석과 아티팩트 로딩 책임을 분리해 유지보수성을 높입니다.

## 🔍 주요 내용

- `LLM/sub_model/query_index_loader.py`를 추가해 검색 인덱스 경로 해석, 키워드 로딩, 임베딩 정규화, BM25 로딩/fallback, 임베딩 모델 초기화를 담당하도록 분리했습니다.
- `query_index.py`는 기존 전역 변수와 `hybrid_search()`, `build_answer()` 인터페이스를 유지하면서 loader에서 준비된 리소스를 사용하도록 변경했습니다.
- 구조 변경에 맞춰 `docs/PLANS.md`의 검색 및 인덱싱 설명을 갱신했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 변경 요약(1~3줄)  
검색 인덱스 로딩/초기화 책임을 LLM/sub_model/query_index_loader.py로 분리해 모듈화와 유지보수성을 개선했습니다. hybrid_search()와 build_answer() 인터페이스는 그대로 두고, 로더가 경로 해석·임베딩·BM25·모델 초기화를 담당합니다.

## 주요 변경점
  - query_index_loader.py 신규 추가: QueryIndexPaths / QueryIndexResources 데이터클래스와 env_path, load_embeddings, load_bm25, load_query_index_resources 등 로딩 로직 통합
  - query_index.py 리팩토링: 경로/로딩 유틸 및 임베딩 정규화 로직 제거, load_query_index_resources() 결과를 전역 변수로 할당하도록 변경
  - BM25 폴백 흐름 명확화: 토큰 코퍼스 유무에 따라 gz 토큰 로드 또는 search_df 기반 토크나이즈로 BM25 생성
  - 임베딩 로드 시 0-노름 보정 및 행별 L2 정규화 적용
  - SentenceTransformer 모델 초기화는 로더에서 수행 (기본 모델: intfloat/multilingual-e5-base)
  - docs/PLANS.md 업데이트: 검색·인덱싱 구조와 loader 역할 반영
  - 보안 패치: pickle 역직렬화 취약점 관련 수정 커밋 포함

## 주의/리스크
  - 모듈 임포트 시 리소스(임베딩, BM25, 모델 등)가 로드되므로 환경변수와 파일 경로가 정확해야 함
  - BM25가 pickle 대신 토크나이즈/코퍼스 재생성 경로로 대체되면서 검색 결과·성능이 달라질 수 있음
  - SentenceTransformer 초기화로 모듈 로드 시간이 길어질 수 있음

## 다음 액션
  - 배포 전 환경변수 및 아티팩트 경로 검증
  - BM25 폴백 경로와 기존 방식 간 검색 결과/성능 비교 테스트
  - hybrid_search/build_answer 통합 동작 및 로드 시간 영향 검증
<!-- end of auto-generated comment: release notes by coderabbit.ai -->