### PR TITLE
chore: validate branch preflight in ci

### DIFF
--- a/.github/workflows/basic-quality-gates.yml
+++ b/.github/workflows/basic-quality-gates.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -34,19 +35,17 @@ jobs:
           python -m pip install numpy pandas pyarrow python-dotenv
 
       - name: Run agent preflight checks
+        env:
+          BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || inputs.base_ref }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            python scripts/agent_checks/run_agent_preflight.py --base "origin/${{ github.base_ref }}"
-          else
-            python scripts/agent_checks/run_agent_preflight.py --base "${{ inputs.base_ref }}"
-          fi
+          python scripts/agent_checks/run_agent_preflight.py --base "$BASE_REF"
 
       - name: Validate RAG eval question set
         run: python tests/regression/chatbot/evaluate_rag_retrieval.py --validate-only
 
       - name: Compile tracked Python files
         run: |
-          git ls-files '*.py' | xargs python -m py_compile
+          git ls-files -z '*.py' | xargs -0 python -m py_compile
 
       - name: Write summary
         if: always()

--- a/.github/workflows/basic-quality-gates.yml
+++ b/.github/workflows/basic-quality-gates.yml
@@ -1,0 +1,62 @@
+name: Basic Quality Gates
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: "Base ref for agent preflight checks"
+        required: false
+        default: "main"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  basic-quality-gates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install lightweight validation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install numpy pandas pyarrow python-dotenv
+
+      - name: Run agent preflight checks
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            python scripts/agent_checks/run_agent_preflight.py --base "origin/${{ github.base_ref }}"
+          else
+            python scripts/agent_checks/run_agent_preflight.py --base "${{ inputs.base_ref }}"
+          fi
+
+      - name: Validate RAG eval question set
+        run: python tests/regression/chatbot/evaluate_rag_retrieval.py --validate-only
+
+      - name: Compile tracked Python files
+        run: |
+          git ls-files '*.py' | xargs python -m py_compile
+
+      - name: Write summary
+        if: always()
+        run: |
+          {
+            echo "## Basic Quality Gates"
+            echo ""
+            echo "- Agent preflight checks: changed scope, secret patterns, generated artifacts, review-output reminders"
+            echo "- RAG eval cases: JSON/schema validation only"
+            echo "- Python files: syntax compilation for tracked \`*.py\` files"
+            echo ""
+            echo "This workflow intentionally avoids model-backed chatbot regression and OCR runtime checks."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 🎯 배경

- PR마다 최소한의 자동 품질 게이트를 실행해 기본적인 보안/범위/문법 문제를 초기에 잡기 위한 작업입니다.
- 모델 기반 RAG/OCR 검사는 무겁기 때문에 기본 CI에서는 제외하고, 기존 선택형 RAG light check와 분리합니다.

## 🔍 주요 내용

- `.github/workflows/basic-quality-gates.yml`를 추가했습니다.
- PR 및 수동 실행에서 agent preflight, RAG eval case schema validation, tracked Python 파일 문법 컴파일을 수행합니다.
- CI summary에 수행한 게이트와 제외한 무거운 런타임 검사를 명시합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 변경 요약
PR과 수동 실행에서 기본 보안/범위/문법 품질 게이트를 빠르게 돌리는 CI 워크플로우를 추가했습니다. 모델 기반 무거운 RAG/OCR 체크는 의도적으로 제외하고, 실행 결과를 요약에 명확히 남기도록 했어요.

## 주요 변경점
- `.github/workflows/basic-quality-gates.yml` 워크플로 추가
- PR 이벤트(`opened`, `synchronize`, `reopened`, `ready_for_review`) 및 수동 실행(`workflow_dispatch`) 지원
- `workflow_dispatch`의 `base_ref` 입력으로 기준 브랜치 선택(기본값 `main`)
- 보안 강화: checkout의 자격증명 유지 비활성화 등 워크플로 주입 위험 완화
- `scripts/agent_checks/run_agent_preflight.py` 실행( PR: `origin/${base_ref}` / 비PR: `inputs.base_ref` 기준)
- `tests/regression/chatbot/evaluate_rag_retrieval.py --validate-only`로 RAG 케이스 스키마만 검증
- 추적 중인 모든 `*.py`에 `py_compile` 문법 컴파일 수행 + `GITHUB_STEP_SUMMARY`에 실행/제외 항목 기록

## 주의/리스크
- 프리플라이트/RAG validate-only가 실제로 기대하는 “기본 품질”을 충분히 커버하는지 확인 필요
- Python 3.11 설치 의존성(`numpy`, `pandas`, `pyarrow`, `python-dotenv`)이 모든 검증에 적합한지 점검

## 다음 액션
- 워크플로 실행 결과에서 각 게이트 성공/실패 원인을 빠르게 모니터링
- `base_ref`를 다른 브랜치로 바꿔 기준 전환 시 동작이 기대대로인지 추가 확인
<!-- end of auto-generated comment: release notes by coderabbit.ai -->