### PR TITLE
chore: add monthly full rag evaluation workflow

### DIFF
--- a/.github/workflows/rag-full-evaluation.yml
+++ b/.github/workflows/rag-full-evaluation.yml
@@ -2,9 +2,6 @@ name: RAG Full Evaluation
 
 on:
   workflow_dispatch:
-  schedule:
-    # GitHub cron is UTC. This runs at 23:00 KST on the 20th of every month.
-    - cron: "0 14 20 * *"
 
 permissions:
   contents: read
@@ -20,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           clean: false
           persist-credentials: false
@@ -66,7 +63,6 @@ jobs:
             echo "## RAG Full Evaluation"
             echo ""
             echo "- Triggered by: \`${{ github.event_name }}\`"
-            echo "- Schedule: monthly on the 20th at 23:00 KST"
             echo "- Runner: self-hosted"
             echo "- Local full report: \`$RAG_EVAL_REPORT_PATH\`"
             echo "- Uploaded summary: \`$RAG_EVAL_SUMMARY_PATH\`"
@@ -125,7 +121,7 @@ jobs:
 
       - name: Upload sanitized RAG summary
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: "rag-eval-summary-${{ steps.report-paths.outputs.report_date }}"
           path: "${{ steps.report-paths.outputs.summary_path }}"

--- a/.github/workflows/rag-full-evaluation.yml
+++ b/.github/workflows/rag-full-evaluation.yml
@@ -1,0 +1,132 @@
+name: RAG Full Evaluation
+
+on:
+  workflow_dispatch:
+  schedule:
+    # GitHub cron is UTC. This runs at 23:00 KST on the 20th of every month.
+    - cron: "0 14 20 * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rag-full-evaluation
+  cancel-in-progress: false
+
+jobs:
+  rag-full-evaluation:
+    runs-on: self-hosted
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          clean: false
+          persist-credentials: false
+
+      - name: Prepare report paths
+        id: report-paths
+        run: |
+          report_date="$(TZ=Asia/Seoul date +%F)"
+          report_path="tests/reports/chatbot/rag_eval_report.json"
+          summary_path="tests/reports/chatbot/${report_date}-rag_eval_summary.json"
+
+          mkdir -p tests/reports/chatbot
+          rm -f "$report_path" "$summary_path"
+
+          echo "RAG_EVAL_REPORT_DATE=$report_date" >> "$GITHUB_ENV"
+          echo "RAG_EVAL_REPORT_PATH=$report_path" >> "$GITHUB_ENV"
+          echo "RAG_EVAL_SUMMARY_PATH=$summary_path" >> "$GITHUB_ENV"
+          echo "report_date=$report_date" >> "$GITHUB_OUTPUT"
+          echo "summary_path=$summary_path" >> "$GITHUB_OUTPUT"
+
+      - name: Check self-hosted RAG prerequisites
+        env:
+          RAG_EVAL_CONDA_ENV: dl_study
+        run: |
+          command -v conda
+          conda run -n "$RAG_EVAL_CONDA_ENV" python --version
+
+          test -f model/artifacts/search_df.parquet
+          test -f model/artifacts/embeddings.npy
+          test -f model/artifacts/bm25.pkl
+          test -f model/artifacts/tokenized_corpus.json.gz
+          test -f model/artifacts/contact_docs.csv
+
+      - name: Run full RAG evaluation
+        env:
+          RAG_EVAL_CONDA_ENV: dl_study
+        run: bash scripts/check_rag_eval.sh
+
+      - name: Write sanitized report summary
+        if: always()
+        run: |
+          {
+            echo "## RAG Full Evaluation"
+            echo ""
+            echo "- Triggered by: \`${{ github.event_name }}\`"
+            echo "- Schedule: monthly on the 20th at 23:00 KST"
+            echo "- Runner: self-hosted"
+            echo "- Local full report: \`$RAG_EVAL_REPORT_PATH\`"
+            echo "- Uploaded summary: \`$RAG_EVAL_SUMMARY_PATH\`"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -f "$RAG_EVAL_REPORT_PATH" ]; then
+            python - "$RAG_EVAL_REPORT_PATH" "$RAG_EVAL_SUMMARY_PATH" "$RAG_EVAL_REPORT_DATE" >> "$GITHUB_STEP_SUMMARY" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          report_path = Path(sys.argv[1])
+          summary_path = Path(sys.argv[2])
+          report_date = sys.argv[3]
+
+          with open(report_path, "r", encoding="utf-8") as f:
+              report = json.load(f)
+          summary = dict(report.get("summary", {}))
+          summary.pop("errors", None)
+
+          safe_report = {
+              "schema_version": 1,
+              "suite": "rag_retrieval_summary",
+              "service": "chatbot",
+              "report_date_kst": report_date,
+              "source_report": report_path.name,
+              "summary": summary,
+          }
+          summary_path.parent.mkdir(parents=True, exist_ok=True)
+          summary_path.write_text(json.dumps(safe_report, ensure_ascii=False, indent=2), encoding="utf-8")
+
+          fields = [
+              ("Total", "total"),
+              ("Passed", "passed"),
+              ("Failed", "failed"),
+              ("Pass rate", "pass_rate"),
+              ("Top3 URL accuracy", "top3_url_accuracy"),
+              ("Source URL pass rate", "source_url_pass_rate"),
+              ("Hallucination proxy rate", "hallucination_proxy_rate"),
+              ("Average retrieval latency ms", "avg_retrieval_latency_ms"),
+              ("P95 retrieval latency ms", "p95_retrieval_latency_ms"),
+          ]
+
+          print("| Metric | Value |")
+          print("| --- | ---: |")
+          for label, key in fields:
+              if key in summary:
+                  print(f"| {label} | {summary[key]} |")
+          print("")
+          print("Detailed queries and answers are kept only in the self-hosted runner workspace.")
+          PY
+          else
+            echo "RAG report was not generated." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload sanitized RAG summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: "rag-eval-summary-${{ steps.report-paths.outputs.report_date }}"
+          path: "${{ steps.report-paths.outputs.summary_path }}"
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__
 hs_err_pid*.log
 tests/regression/**/reports/
 tests/reports/**/*.json
+!tests/reports/chatbot/*-rag_eval_summary.json
 
 # Local dependencies
 requirements.txt

--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ Kakao map 기반 학교 주변 1Km 이내 식당을 확인할 수 있습니다.
 - 평가 범위: 학사일정, 연락처, 장학금, 수강신청, 졸업, 학과/기숙사 안내
 - 검색 평가: top-k 검색 결과에 기대 URL/문서가 포함되는지 `Recall@1`, `Recall@3` 측정
 - 답변 평가: 필수 키워드, 날짜 형식, 출처 URL 포함 여부, 비공식 URL 환각 여부 점검
-- 자동화: `RAG Light Check` GitHub Actions가 PR 라벨 `run-rag-check` 또는 수동 실행에서 질문 세트 스키마와 경량 query-index 회귀를 검증
+- 자동화: `RAG Light Check` GitHub Actions가 PR 라벨 `run-rag-check` 또는 수동 실행에서 질문 세트 스키마와 경량 query-index 회귀를 검증하고, `RAG Full Evaluation`은 self-hosted runner에서 매월 20일 23:00 KST 또는 수동 실행으로 전체 RAG 리포트를 생성합니다. GitHub artifact에는 상세 질문/답변을 제외한 날짜 prefix summary만 업로드합니다.
 
 ```bash
 # 질문 세트 스키마 검증
 python tests/regression/chatbot/evaluate_rag_retrieval.py --validate-only
 
 # 로컬 모델/아티팩트 기반 전체 RAG 평가
-python tests/regression/chatbot/evaluate_rag_retrieval.py --out /tmp/rag_eval_report.json --fail-on-fail
+python tests/regression/chatbot/evaluate_rag_retrieval.py --out tests/reports/chatbot/rag_eval_report.json --fail-on-fail
 
 # OSS FastAPI 서버 대상 API 회귀 평가
 python tests/regression/chatbot/run_chatbot_regression.py --url http://127.0.0.1:8010/chatbot
@@ -92,7 +92,7 @@ python tests/regression/chatbot/run_chatbot_regression.py --url http://127.0.0.1
 
 | 구분 | 질문 세트 | 검색 Recall@3 | 답변 근거성 | 비고 |
 | --- | ---: | ---: | ---: | --- |
-| 개선 전 기준선 | 30개 | 리포트 기준값 | 리포트 기준값 | `/tmp/rag_eval_report.json` 또는 저장된 baseline 리포트 |
+| 개선 전 기준선 | 30개 | 리포트 기준값 | 리포트 기준값 | `tests/reports/chatbot/rag_eval_report.json` 또는 저장된 baseline 리포트 |
 | 현재 브랜치 | 30개 | `summary.top3_url_accuracy` | `summary.source_url_pass_rate` | `tests/regression/chatbot/evaluate_rag_retrieval.py` 실행 결과로 갱신 |
 | CI 경량 회귀 | synthetic + schema | 통과/실패 | 통과/실패 | 무거운 임베딩 모델 다운로드 없이 PR에서 빠르게 검증 |
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Kakao map 기반 학교 주변 1Km 이내 식당을 확인할 수 있습니다.
 - 평가 범위: 학사일정, 연락처, 장학금, 수강신청, 졸업, 학과/기숙사 안내
 - 검색 평가: top-k 검색 결과에 기대 URL/문서가 포함되는지 `Recall@1`, `Recall@3` 측정
 - 답변 평가: 필수 키워드, 날짜 형식, 출처 URL 포함 여부, 비공식 URL 환각 여부 점검
-- 자동화: `RAG Light Check` GitHub Actions가 PR 라벨 `run-rag-check` 또는 수동 실행에서 질문 세트 스키마와 경량 query-index 회귀를 검증하고, `RAG Full Evaluation`은 self-hosted runner에서 매월 20일 23:00 KST 또는 수동 실행으로 전체 RAG 리포트를 생성합니다. GitHub artifact에는 상세 질문/답변을 제외한 날짜 prefix summary만 업로드합니다.
+- 자동화: `RAG Light Check` GitHub Actions가 PR 라벨 `run-rag-check` 또는 수동 실행에서 질문 세트 스키마와 경량 query-index 회귀를 검증합니다. `RAG Full Evaluation`은 self-hosted runner가 준비되면 수동 실행으로 전체 RAG 리포트를 생성하며, GitHub artifact에는 상세 질문/답변을 제외한 날짜 prefix summary만 업로드합니다. runner가 준비되기 전에는 로컬에서 전체 RAG 평가를 수동 실행합니다.
 
 ```bash
 # 질문 세트 스키마 검증


### PR DESCRIPTION
## 🎯 배경

- full RAG 평가는 모델 아티팩트, conda 환경, 로컬 캐시 의존성이 있어 기본 PR CI에서 실행하기 부담이 큽니다.
- self-hosted runner에서 월 1회 또는 수동으로 전체 RAG 평가를 실행하고, GitHub에는 공개 가능한 요약 리포트만 남기도록 자동화가 필요했습니다.

## 🔍 주요 내용

- `RAG Full Evaluation` GitHub Actions workflow를 추가했습니다.
- workflow는 self-hosted runner에서 매월 20일 23:00 KST 또는 수동 실행으로 동작합니다.
- 기존 `scripts/check_rag_eval.sh`를 재사용해 full RAG report를 생성합니다.
- 상세 질문/답변이 포함된 원본 report는 runner 로컬에만 두고, GitHub artifact에는 날짜 prefix가 붙은 sanitized summary만 업로드합니다.
- `.gitignore`에서 `tests/reports/**/*.json`은 계속 ignore하되, `tests/reports/chatbot/*-rag_eval_summary.json`은 공개 가능한 요약 리포트로 추적 가능하게 예외 처리했습니다.
- README의 RAG 리포트 경로 예시를 `tests/reports/chatbot/rag_eval_report.json` 기준으로 정리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 요약
매월 20일 23:00 KST에 자동 실행되는 RAG 전체 평가 워크플로우를 추가했습니다. 상세 평가 결과는 로컬에만 보관하고, 요약 리포트만 GitHub Artifacts에 공개하는 방식으로 구현했습니다.

## 주요 변경점
- **RAG Full Evaluation 워크플로우 추가** - 월 1회 자동 실행 또는 수동 트리거 가능하며 self-hosted 러너에서 동작
- **준비 단계 강화** - KST 기준 날짜 계산, 모델 아티팩트 및 Python 환경 검증
- **요약 리포트 생성 및 업로드** - 원본 JSON에서 민감 정보(`errors` 필드 등)를 제거한 sanitized 요약 생성
- **GitHub Step Summary 기록** - 실행 일정, 러너 정보, 경로 등 메타정보를 단계별로 기록
- **.gitignore 예외 규칙 추가** - `*-rag_eval_summary.json` 파일은 추적 가능하도록 명시적 제외
- **README 문서 업데이트** - RAG 평가 경로 및 워크플로우 설명 추가

## 주의/리스크
- Self-hosted 러너의 가용성에 따라 월간 평가 실행이 영향받을 수 있음
- 모델 아티팩트 파일 누락 시 평가가 실패하므로 러너의 환경 관리 필요

## 다음 액션
- Self-hosted 러너 상태 모니터링 및 정기 점검
- 모델 아티팩트 파일의 접근성 및 갱신 주기 확인

<!-- end of auto-generated comment: release notes by coderabbit.ai -->