### PR TITLE
feat: add timetable ocr diagnostics report

### DIFF
--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -39,6 +39,18 @@ python tests/regression/timetable/check_timetable_ocr_diagnostics.py
 
 카테고리별 결과는 `summary.by_category`에 `passed`, `failed`, `pass_rate`와 함께 같은 제품 지표 일부를 저장합니다. 현재 RAG 평가는 `LLM.sub_model.query_index.build_answer()`와 `schedule_search()`를 직접 호출하므로, API/LLM 라우팅 전체의 거절 정책 평가는 별도 API 회귀 테스트에서 다룹니다.
 
+### Timetable OCR Diagnostics Metrics
+
+`tests/regression/timetable/check_timetable_ocr_diagnostics.py`는 `tests/regression/timetable/timetable_ocr_diagnostic_cases.json`의 케이스를 읽어 시간표 OCR 진단 리포트를 생성합니다.
+
+- `grid_detection_success_rate`: 케이스별 최소 격자 라인 기준을 통과한 비율
+- `extracted_course_count`: 추출된 시간표 항목 수
+- `average_empty_cell_ratio`: OCR 대상 셀 중 텍스트가 없는 셀 비율 평균
+- `average_ocr_confidence`: 진단 OCR confidence 평균
+- `fallback_cell_count`: fallback OCR 경로가 선택된 셀 수
+
+`cv2`, `pytesseract`, Tesseract 런타임이 없는 환경에서는 실패 대신 `status: "skipped"` 리포트를 기본 경로에 기록합니다.
+
 ## Common JSON Summary
 
 각 리포트는 가능한 한 아래 summary 형식을 따릅니다. 상세 지표는 suite마다 다를 수 있으므로 `metrics` 안에 둡니다.
@@ -54,8 +66,11 @@ python tests/regression/timetable/check_timetable_ocr_diagnostics.py
   "failed": 0,
   "skipped": 0,
   "metrics": {
-    "average_confidence": 87.33,
-    "fallback_cells": 1
+    "grid_detection_success_rate": 1.0,
+    "extracted_course_count": 4,
+    "average_empty_cell_ratio": 0.0,
+    "average_ocr_confidence": 87.33,
+    "fallback_cell_count": 78
   },
   "errors": []
 }

--- a/tests/regression/timetable/check_timetable_ocr_diagnostics.py
+++ b/tests/regression/timetable/check_timetable_ocr_diagnostics.py
@@ -185,7 +185,7 @@ def evaluate_case(case: Dict[str, Any], cv2, np, ocr_engine) -> Dict[str, Any]:
     ocr = diagnostics.get("ocr", {})
     metrics = {
         "grid_detection_success": grid_detection_success(grid, expected),
-        "extracted_course_count": diagnostics.get("schedule_count", 0),
+        "extracted_course_count": len(schedules),
         "empty_cell_ratio": empty_cell_ratio(ocr),
         "ocr_confidence": ocr.get("average_confidence"),
         "fallback_cell_count": ocr.get("fallback_cells", 0),

--- a/tests/regression/timetable/check_timetable_ocr_diagnostics.py
+++ b/tests/regression/timetable/check_timetable_ocr_diagnostics.py
@@ -1,142 +1,297 @@
 #!/usr/bin/env python3
 import argparse
+import importlib
 import json
 import sys
 from pathlib import Path
+from typing import Any, Dict, List, Optional
 from unittest.mock import patch
 
 ROOT_DIR = Path(__file__).resolve().parents[3]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
+
+DEFAULT_CASES_PATH = ROOT_DIR / "tests" / "regression" / "timetable" / "timetable_ocr_diagnostic_cases.json"
 DEFAULT_REPORT_PATH = ROOT_DIR / "tests" / "reports" / "timetable" / "timetable_ocr_diagnostics_report.json"
-
-try:
-    import cv2
-    import numpy as np
-    from image_analysis.ocr_engine import ( # noqa: E402
-        assess_image_quality,
-        extract_schedule_fixed_scaled,
-        extract_schedule_with_diagnostics,
-    )
-except ModuleNotFoundError as exc:
-    print(f"[SKIP] timetable OCR diagnostics dependency is missing: {exc.name}")
-    raise SystemExit(2) from exc
+SUITE = "timetable_ocr_diagnostics"
+SERVICE = "timetable"
 
 
-def make_synthetic_timetable() -> np.ndarray:
-    image = np.full((1600, 1000, 3), 255, dtype=np.uint8)
-    for x in range(80, 921, 140):
-        cv2.line(image, (x, 80), (x, 1480), (0, 0, 0), 3)
-    for y in range(80, 1481, 100):
-        cv2.line(image, (80, y), (920, y), (0, 0, 0), 3)
-    cv2.putText(image, "class", (380, 410), cv2.FONT_HERSHEY_SIMPLEX, 1.0, (0, 0, 0), 2)
-    return image
+def load_cases(path: Path) -> List[Dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    cases = payload.get("cases", [])
+    if not isinstance(cases, list) or not cases:
+        raise ValueError(f"no timetable OCR cases found in {path}")
+    return cases
 
 
-def fake_image_to_string(*args, **kwargs) -> str:
-    config = kwargs.get("config", "")
-    if "--psm 6" in config:
-        return "자료구조\n"
-    return "자료구조\n김교수\nB101\n"
-
-
-def fake_image_to_data(*args, **kwargs) -> dict:
-    config = kwargs.get("config", "")
-    if "--psm 6" in config:
-        return {"conf": ["42.0"]}
-    return {"conf": ["87.0", "90.0", "85.0"]}
-
-
-def main() -> int:
-    ap = argparse.ArgumentParser(description="Check timetable OCR diagnostics contract")
-    ap.add_argument("--out", default=str(DEFAULT_REPORT_PATH), help="output report path")
-    args = ap.parse_args()
-
-    image = make_synthetic_timetable()
-    quality = assess_image_quality(image)
-    errors = []
-    if quality["width"] != 1000 or quality["height"] != 1600:
-        errors.append(f"unexpected_quality_size:{quality}")
-
-    with patch("pytesseract.image_to_string", side_effect=fake_image_to_string), patch(
-        "pytesseract.image_to_data",
-        side_effect=fake_image_to_data,
-    ):
-        report = extract_schedule_with_diagnostics(image)
-
-    diagnostics = report["diagnostics"]
-    ocr = diagnostics["ocr"]
-    if "image_quality" not in diagnostics:
-        errors.append("missing_image_quality")
-    if diagnostics["grid"]["x_line_count"] < 3 or diagnostics["grid"]["y_line_count"] < 3:
-        errors.append(f"weak_grid_detection:{diagnostics['grid']}")
-    if ocr["fallback_cells"] < 1:
-        errors.append(f"fallback_not_used:{ocr}")
-    if ocr["average_confidence"] is None:
-        errors.append(f"missing_average_confidence:{ocr}")
-    if "rejected_cells" not in ocr:
-        errors.append("missing_rejected_cells")
-
-    call_counts = {"string": 0, "data": 0}
-
-    def fast_image_to_string(*args, **kwargs) -> str:
-        call_counts["string"] += 1
-        return "자료구조\n김교수\nB101\n"
-
-    def forbidden_image_to_data(*args, **kwargs) -> dict:
-        call_counts["data"] += 1
-        return {"conf": ["1.0"]}
-
-    with patch("pytesseract.image_to_string", side_effect=fast_image_to_string), patch(
-        "pytesseract.image_to_data",
-        side_effect=forbidden_image_to_data,
-    ):
-        extract_schedule_fixed_scaled(image)
-
-    if call_counts["string"] < 1:
-        errors.append("fast_path_ocr_not_called")
-    if call_counts["data"] != 0:
-        errors.append(f"fast_path_called_confidence_ocr:{call_counts}")
-
-    average_confidence = ocr.get("average_confidence")
-    summary = {
-        "schema_version": 1,
-        "suite": "timetable_ocr_diagnostics",
-        "service": "timetable",
-        "status": "failed" if errors else "passed",
-        "total": 1,
-        "passed": 0 if errors else 1,
-        "failed": 1 if errors else 0,
-        "skipped": 0,
-        "metrics": {
-            "average_confidence": average_confidence,
-            "fallback_cells": ocr.get("fallback_cells", 0),
-            "accepted_cells": ocr.get("accepted_cells", 0),
-            "rejected_cells": len(ocr.get("rejected_cells", [])),
-            "schedule_count": diagnostics.get("schedule_count", 0),
-        },
-        "errors": errors,
-    }
-    output = {
-        "schema_version": 1,
-        "suite": "timetable_ocr_diagnostics",
-        "service": "timetable",
-        "summary": summary,
-        "diagnostics": diagnostics,
-        "fast_path_call_counts": call_counts,
-    }
-    out_path = Path(args.out)
+def write_report(out_path: Path, output: Dict[str, Any]) -> None:
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(output, ensure_ascii=False, indent=2), encoding="utf-8")
 
-    if errors:
+
+def make_summary(status: str, total: int, passed: int, failed: int, skipped: int, metrics: Dict[str, Any], errors: List[str]) -> Dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "suite": SUITE,
+        "service": SERVICE,
+        "status": status,
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "skipped": skipped,
+        "metrics": metrics,
+        "errors": errors,
+    }
+
+
+def write_skipped_report(out_path: Path, reason: str, cases_path: Path) -> None:
+    summary = make_summary(
+        status="skipped",
+        total=0,
+        passed=0,
+        failed=0,
+        skipped=1,
+        metrics={},
+        errors=[],
+    )
+    output = {
+        "schema_version": 1,
+        "suite": SUITE,
+        "service": SERVICE,
+        "summary": summary,
+        "cases_path": str(cases_path),
+        "skipped": {
+            "reason": reason,
+        },
+        "case_results": [],
+    }
+    write_report(out_path, output)
+    print(f"[SKIP] {reason}")
+    print(json.dumps(summary, ensure_ascii=False))
+    print(f"report={out_path}")
+
+
+def load_ocr_dependencies(out_path: Path, cases_path: Path):
+    try:
+        cv2 = importlib.import_module("cv2")
+        np = importlib.import_module("numpy")
+        pytesseract = importlib.import_module("pytesseract")
+        ocr_engine = importlib.import_module("image_analysis.ocr_engine")
+    except ModuleNotFoundError as exc:
+        write_skipped_report(out_path, f"timetable OCR diagnostics dependency is missing: {exc.name}", cases_path)
+        raise SystemExit(0) from exc
+
+    try:
+        pytesseract.get_tesseract_version()
+    except Exception as exc:
+        write_skipped_report(out_path, f"Tesseract runtime is unavailable: {exc}", cases_path)
+        raise SystemExit(0) from exc
+
+    return cv2, np, ocr_engine
+
+
+def make_synthetic_timetable(case: Dict[str, Any], cv2, np):
+    spec = case.get("input", {}).get("synthetic_grid", {})
+    width = int(spec.get("width", 1000))
+    height = int(spec.get("height", 1600))
+    background = int(spec.get("background", 255))
+    image = np.full((height, width, 3), background, dtype=np.uint8)
+
+    line_color = tuple(spec.get("line_color", [0, 0, 0]))
+    line_thickness = int(spec.get("line_thickness", 3))
+    vertical_line_thickness = int(spec.get("vertical_line_thickness", line_thickness))
+    horizontal_line_thickness = int(spec.get("horizontal_line_thickness", line_thickness))
+    horizontal_x_start = int(spec.get("horizontal_x_start", spec.get("x_start", 80)))
+    horizontal_x_end = int(spec.get("horizontal_x_end", spec.get("x_end", 920)))
+    for x in range(int(spec.get("x_start", 80)), int(spec.get("x_stop", 921)), int(spec.get("x_step", 140))):
+        cv2.line(
+            image,
+            (x, int(spec.get("y_start", 80))),
+            (x, int(spec.get("y_end", 1480))),
+            line_color,
+            vertical_line_thickness,
+        )
+    for y in range(int(spec.get("y_start", 80)), int(spec.get("y_stop", 1481)), int(spec.get("y_step", 100))):
+        cv2.line(image, (horizontal_x_start, y), (horizontal_x_end, y), line_color, horizontal_line_thickness)
+
+    label = spec.get("label")
+    if label:
+        cv2.putText(
+            image,
+            str(label.get("text", "class")),
+            (int(label.get("x", 380)), int(label.get("y", 410))),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            float(label.get("scale", 1.0)),
+            line_color,
+            int(label.get("thickness", 2)),
+        )
+    return image
+
+
+def build_mock_ocr(case: Dict[str, Any]):
+    mock = case.get("mock_ocr", {})
+    primary = mock.get("primary", {})
+    fallback = mock.get("fallback", {})
+
+    def image_to_string(*args, **kwargs) -> str:
+        config = kwargs.get("config", "")
+        lines = fallback.get("lines", []) if "--psm 11" in config else primary.get("lines", [])
+        return "\n".join(lines) + ("\n" if lines else "")
+
+    def image_to_data(*args, **kwargs) -> dict:
+        config = kwargs.get("config", "")
+        conf = fallback.get("confidence", []) if "--psm 11" in config else primary.get("confidence", [])
+        return {"conf": [str(value) for value in conf]}
+
+    return image_to_string, image_to_data
+
+
+def grid_detection_success(grid: Dict[str, Any], expected: Dict[str, Any]) -> bool:
+    min_x = int(expected.get("min_x_lines", 3))
+    min_y = int(expected.get("min_y_lines", 3))
+    return int(grid.get("x_line_count", 0)) >= min_x and int(grid.get("y_line_count", 0)) >= min_y
+
+
+def empty_cell_ratio(ocr: Dict[str, Any]) -> Optional[float]:
+    total = int(ocr.get("total_cells", 0))
+    if total <= 0:
+        return None
+    text_cells = int(ocr.get("text_cells", 0))
+    return round((total - text_cells) / total, 4)
+
+
+def evaluate_case(case: Dict[str, Any], cv2, np, ocr_engine) -> Dict[str, Any]:
+    image = make_synthetic_timetable(case, cv2, np)
+    quality = ocr_engine.assess_image_quality(image)
+    expected = case.get("expected", {})
+    errors: List[str] = []
+
+    if quality["width"] != case.get("input", {}).get("synthetic_grid", {}).get("width", 1000):
+        errors.append(f"unexpected_quality_width:{quality}")
+    if quality["height"] != case.get("input", {}).get("synthetic_grid", {}).get("height", 1600):
+        errors.append(f"unexpected_quality_height:{quality}")
+
+    mock_string, mock_data = build_mock_ocr(case)
+    with patch("pytesseract.image_to_string", side_effect=mock_string), patch(
+        "pytesseract.image_to_data",
+        side_effect=mock_data,
+    ):
+        report = ocr_engine.extract_schedule_with_diagnostics(image)
+
+    diagnostics = report["diagnostics"]
+    schedules = report.get("schedules", [])
+    grid = diagnostics.get("grid", {})
+    ocr = diagnostics.get("ocr", {})
+    metrics = {
+        "grid_detection_success": grid_detection_success(grid, expected),
+        "extracted_course_count": diagnostics.get("schedule_count", 0),
+        "empty_cell_ratio": empty_cell_ratio(ocr),
+        "ocr_confidence": ocr.get("average_confidence"),
+        "fallback_cell_count": ocr.get("fallback_cells", 0),
+        "accepted_cell_count": ocr.get("accepted_cells", 0),
+        "rejected_cell_count": len(ocr.get("rejected_cells", [])),
+        "low_confidence_cell_count": ocr.get("low_confidence_cells", 0),
+    }
+
+    if not metrics["grid_detection_success"]:
+        errors.append(f"grid_detection_failed:{grid}")
+    if metrics["extracted_course_count"] < int(expected.get("min_extracted_course_count", 1)):
+        errors.append(f"course_count_below_expected:{metrics['extracted_course_count']}")
+    if metrics["fallback_cell_count"] < int(expected.get("min_fallback_cell_count", 0)):
+        errors.append(f"fallback_count_below_expected:{metrics['fallback_cell_count']}")
+    min_confidence = expected.get("min_ocr_confidence")
+    if min_confidence is not None and (metrics["ocr_confidence"] is None or metrics["ocr_confidence"] < float(min_confidence)):
+        errors.append(f"ocr_confidence_below_expected:{metrics['ocr_confidence']}")
+    max_empty_ratio = expected.get("max_empty_cell_ratio")
+    if max_empty_ratio is not None and metrics["empty_cell_ratio"] is not None and metrics["empty_cell_ratio"] > float(max_empty_ratio):
+        errors.append(f"empty_cell_ratio_above_expected:{metrics['empty_cell_ratio']}")
+
+    return {
+        "id": case.get("id"),
+        "name": case.get("name"),
+        "status": "failed" if errors else "passed",
+        "metrics": metrics,
+        "errors": errors,
+        "schedules": schedules,
+        "diagnostics": diagnostics,
+    }
+
+
+def aggregate_metrics(case_results: List[Dict[str, Any]]) -> Dict[str, Any]:
+    if not case_results:
+        return {}
+
+    confidence_values = [
+        result["metrics"]["ocr_confidence"]
+        for result in case_results
+        if result["metrics"].get("ocr_confidence") is not None
+    ]
+    empty_ratios = [
+        result["metrics"]["empty_cell_ratio"]
+        for result in case_results
+        if result["metrics"].get("empty_cell_ratio") is not None
+    ]
+    return {
+        "grid_detection_success_rate": round(
+            sum(1 for result in case_results if result["metrics"].get("grid_detection_success")) / len(case_results),
+            4,
+        ),
+        "extracted_course_count": sum(int(result["metrics"].get("extracted_course_count", 0)) for result in case_results),
+        "average_empty_cell_ratio": round(sum(empty_ratios) / len(empty_ratios), 4) if empty_ratios else None,
+        "average_ocr_confidence": round(sum(confidence_values) / len(confidence_values), 2) if confidence_values else None,
+        "fallback_cell_count": sum(int(result["metrics"].get("fallback_cell_count", 0)) for result in case_results),
+        "accepted_cell_count": sum(int(result["metrics"].get("accepted_cell_count", 0)) for result in case_results),
+        "rejected_cell_count": sum(int(result["metrics"].get("rejected_cell_count", 0)) for result in case_results),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Write a timetable OCR diagnostics report")
+    ap.add_argument("--cases", default=str(DEFAULT_CASES_PATH), help="golden OCR diagnostic cases path")
+    ap.add_argument("--out", default=str(DEFAULT_REPORT_PATH), help="output report path")
+    args = ap.parse_args()
+
+    out_path = Path(args.out)
+    cases_path = Path(args.cases)
+    cases = load_cases(cases_path)
+    cv2, np, ocr_engine = load_ocr_dependencies(out_path, cases_path)
+
+    case_results = [evaluate_case(case, cv2, np, ocr_engine) for case in cases]
+    errors = [
+        f"{result['id']}:{error}"
+        for result in case_results
+        for error in result.get("errors", [])
+    ]
+    failed = sum(1 for result in case_results if result["status"] == "failed")
+    passed = len(case_results) - failed
+    summary = make_summary(
+        status="failed" if failed else "passed",
+        total=len(case_results),
+        passed=passed,
+        failed=failed,
+        skipped=0,
+        metrics=aggregate_metrics(case_results),
+        errors=errors,
+    )
+    output = {
+        "schema_version": 1,
+        "suite": SUITE,
+        "service": SERVICE,
+        "summary": summary,
+        "cases_path": str(cases_path),
+        "case_results": case_results,
+    }
+    write_report(out_path, output)
+
+    if failed:
         for error in errors:
             print(f"[FAIL] {error}")
         print(json.dumps(summary, ensure_ascii=False))
         print(f"report={out_path}")
         return 1
 
-    print("[OK] timetable OCR diagnostics contract")
+    print("[OK] timetable OCR diagnostics report")
     print(json.dumps(summary, ensure_ascii=False))
     print(f"report={out_path}")
     return 0

--- a/tests/regression/timetable/timetable_ocr_diagnostic_cases.json
+++ b/tests/regression/timetable/timetable_ocr_diagnostic_cases.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "suite": "timetable_ocr_diagnostics",
+  "cases": [
+    {
+      "id": "synthetic_low_confidence_fallback",
+      "name": "Synthetic timetable grid with fallback OCR candidate",
+      "input": {
+        "type": "synthetic_grid",
+        "synthetic_grid": {
+          "width": 1000,
+          "height": 1600,
+          "x_start": 80,
+          "x_stop": 921,
+          "x_step": 140,
+          "x_end": 920,
+          "y_start": 80,
+          "y_stop": 1481,
+          "y_step": 100,
+          "y_end": 1480,
+          "line_thickness": 3,
+          "vertical_line_thickness": 1,
+          "horizontal_line_thickness": 3,
+          "horizontal_x_start": 0,
+          "horizontal_x_end": 999,
+          "label": {
+            "text": "class",
+            "x": 380,
+            "y": 410,
+            "scale": 1.0,
+            "thickness": 2
+          }
+        }
+      },
+      "mock_ocr": {
+        "primary": {
+          "lines": [
+            "자료구조"
+          ],
+          "confidence": [
+            42.0
+          ]
+        },
+        "fallback": {
+          "lines": [
+            "자료구조",
+            "김교수",
+            "B101"
+          ],
+          "confidence": [
+            87.0,
+            90.0,
+            85.0
+          ]
+        }
+      },
+      "expected": {
+        "min_x_lines": 3,
+        "min_y_lines": 3,
+        "min_extracted_course_count": 1,
+        "min_fallback_cell_count": 1,
+        "min_ocr_confidence": 80.0,
+        "max_empty_cell_ratio": 0.1
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## 🎯 배경
- 시간표 OCR 진단 결과를 기능별 리포트 경로에 자동 저장하고, OCR 품질 지표를 리뷰/CI에서 확인할 수 있도록 개선합니다.
- cv2 또는 Tesseract 런타임이 없는 환경에서도 원인을 확인할 수 있는 skipped 리포트를 남깁니다.

## 🔍 주요 내용
- tests/regression/timetable/check_timetable_ocr_diagnostics.py를 케이스 파일 기반 리포트 생성 스크립트로 확장
- tests/regression/timetable/timetable_ocr_diagnostic_cases.json에 synthetic OCR 진단 케이스와 기대 기준 분리
- grid detection, extracted course count, empty cell ratio, OCR confidence, fallback cell count 지표 추가
- tests/reports/timetable/timetable_ocr_diagnostics_report.json 기본 출력 유지
- OCR 진단 metrics와 skipped 동작을 tests/regression/README.md에 문서화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 변경 요약
시간표 OCR 진단 리포트 시스템을 도입해 격자 검출, 추출 강의 수, 빈 셀 비율, OCR confidence, fallback 셀 수 등 5가지 진단 지표를 자동 수집합니다. 기존 단일 합성 이미지 기반 검증에서 JSON 케이스 파일 기반 회귀 테스트로 전환되어 다중 케이스 평가가 가능해졌으며, 의존성 부재 시에도 "skipped" 리포트로 우아하게 처리됩니다.

## 주요 변경점
- **케이스 기반 테스트 시스템**: `timetable_ocr_diagnostic_cases.json`을 로드해 여러 케이스를 순차 평가하고 `tests/reports/timetable/timetable_ocr_diagnostics_report.json`으로 결과 저장
- **의존성 지연 로드**: cv2, pytesseract, Tesseract 런타임을 선택적으로 로드하며 부재 시 "skipped" 리포트 자동 생성
- **동적 합성 시간표**: 케이스별 그리드 스펙(너비, 높이, 선 색, 간격, 두께, 스케일 등)에 따라 유연하게 생성
- **향상된 진단 메트릭**: grid 성공 여부, 추출 강의 수, 빈 셀 비율, 평균 OCR confidence, fallback 셀 수 등 계산
- **조건 기반 검증**: 기대값과의 폭·높이 일치 및 각 메트릭의 상한/하한 조건 검증하여 pass/fail 판정
- **케이스 집계 로직**: `aggregate_metrics()`로 전체 케이스의 메트릭 평균/합계 계산
- **문서화 추가**: `tests/regression/README.md`에 OCR 진단 지표 설명과 skipped 동작 문서화

## 주의/리스크
- **의존성 환경 설정**: cv2, pytesseract, Tesseract 런타임이 필수이므로 CI 환경에서 이들이 제대로 설치되어 있는지 확인 필요
- **케이스 스키마 유지**: 새로운 테스트 케이스 추가 시 `input`(합성 그리드 스펙), `expected`(기대값) 구조 준수 필수

## 다음 액션
- **테스트 케이스 확대**: 현재 `synthetic_low_confidence_fallback` 단일 케이스만 존재하므로 다양한 OCR 시나리오(높은 신뢰도, 그리드 실패, 빈 셀 많음 등) 케이스 추가 검토
- **CI/CD 통합 검증**: 진단 리포트가 빌드 파이프라인에서 자동 생성되는지, 리포트 경로가 올바른지 확인
<!-- end of auto-generated comment: release notes by coderabbit.ai -->