### PR TITLE
test: add text filter regression cases

### DIFF
--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -4,6 +4,7 @@
 
 - `chatbot/`: OSS 챗봇, RAG 검색 품질, query-index 호환성, tool routing 회귀 테스트
 - `timetable/`: 시간표 OCR, 이미지 품질 진단, 셀/그리드 분석 회귀 테스트
+- `text_filtering/`: 텍스트 필터링 품질, 정상 문장 오탐/비속어 미탐 회귀 테스트
 
 대표 실행 명령:
 
@@ -12,6 +13,7 @@ python tests/regression/chatbot/evaluate_rag_retrieval.py --validate-only
 python tests/regression/chatbot/evaluate_rag_retrieval.py
 python tests/regression/chatbot/check_chatbot_tool_routing.py
 python tests/regression/timetable/check_timetable_ocr_diagnostics.py
+python tests/regression/text_filtering/check_text_filter_quality_report.py
 ```
 
 ## Evaluation Metrics Policy
@@ -50,6 +52,19 @@ python tests/regression/timetable/check_timetable_ocr_diagnostics.py
 - `fallback_cell_count`: fallback OCR 경로가 선택된 셀 수
 
 `cv2`, `pytesseract`, Tesseract 런타임이 없는 환경에서는 실패 대신 `status: "skipped"` 리포트를 기본 경로에 기록합니다.
+
+### Text Filtering Quality Metrics
+
+`tests/regression/text_filtering/check_text_filter_quality_report.py`는 `tests/regression/text_filtering/text_filter_quality_cases.json`의 케이스를 읽어 기존 텍스트 필터 판정 로직을 평가합니다.
+
+- `false_positive_count`: 정상 문장을 비속어로 판정한 케이스 수
+- `false_negative_count`: 비속어 문장을 정상으로 판정한 케이스 수
+- `pass_rate`: 전체 golden case 기대값과 실제 결과가 일치한 비율
+- `ml_filter_pass_rate`: 현재 ML 기반 판정 경로 기준 통과율
+- `rule_endpoint_pass_rate`: 현재 `/text_filter_rule` API 계약의 공유 판정 경로 기준 통과율
+
+이 스크립트는 `analyze_text_labels()`만 호출하므로 테스트 문장을 `data/bad_text_sample.txt`에 append하지 않습니다. 모델 파일 또는 의존성이 없는 환경에서는 실패 대신 `status: "skipped"` 리포트를 기본 경로에 기록합니다.
+기본 실행은 품질 리포트를 기록하고 종료 코드는 0으로 유지합니다. 품질 실패를 게이트로 쓰려면 `--strict`를 함께 사용합니다.
 
 ## Common JSON Summary
 

--- a/tests/regression/text_filtering/check_text_filter_quality_report.py
+++ b/tests/regression/text_filtering/check_text_filter_quality_report.py
@@ -206,11 +206,15 @@ def main() -> int:
     validation_errors = validate_cases(cases)
 
     if validation_errors:
+        failed_case_ids = {
+            (err.split(":", 1)[0] if ":" in err else err)
+            for err in validation_errors
+        }
         summary = make_summary(
             status="failed",
             total=len(cases),
             passed=0,
-            failed=len(validation_errors),
+            failed=len(failed_case_ids),
             skipped=0,
             metrics={},
             errors=validation_errors,

--- a/tests/regression/text_filtering/check_text_filter_quality_report.py
+++ b/tests/regression/text_filtering/check_text_filter_quality_report.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+DEFAULT_CASES_PATH = ROOT_DIR / "tests" / "regression" / "text_filtering" / "text_filter_quality_cases.json"
+DEFAULT_REPORT_PATH = ROOT_DIR / "tests" / "reports" / "text_filtering" / "text_filter_quality_report.json"
+SUITE = "text_filter_quality"
+SERVICE = "text_filtering"
+
+
+def load_cases(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    cases = payload.get("cases", [])
+    if not isinstance(cases, list) or not cases:
+        raise ValueError(f"no text filtering cases found in {path}")
+    return cases
+
+
+def validate_cases(cases: list[dict[str, Any]]) -> list[str]:
+    errors: list[str] = []
+    seen_ids: set[str] = set()
+
+    for idx, case in enumerate(cases, start=1):
+        case_id = str(case.get("id", "") or "")
+        prefix = case_id or f"case#{idx}"
+
+        if not case_id:
+            errors.append(f"{prefix}:missing_id")
+        elif case_id in seen_ids:
+            errors.append(f"{prefix}:duplicate_id")
+        seen_ids.add(case_id)
+
+        if not str(case.get("category", "") or "").strip():
+            errors.append(f"{prefix}:missing_category")
+        if not str(case.get("text", "") or "").strip():
+            errors.append(f"{prefix}:missing_text")
+
+        expected = case.get("expected")
+        if not isinstance(expected, dict):
+            errors.append(f"{prefix}:missing_expected")
+            continue
+        if not isinstance(expected.get("has_profanity"), bool):
+            errors.append(f"{prefix}:expected_has_profanity_must_be_bool")
+
+    return errors
+
+
+def write_report(out_path: Path, output: dict[str, Any]) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(output, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def make_summary(
+    status: str,
+    total: int,
+    passed: int,
+    failed: int,
+    skipped: int,
+    metrics: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "suite": SUITE,
+        "service": SERVICE,
+        "status": status,
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "skipped": skipped,
+        "metrics": metrics,
+        "errors": errors,
+    }
+
+
+def write_skipped_report(out_path: Path, reason: str, cases_path: Path) -> None:
+    summary = make_summary(
+        status="skipped",
+        total=0,
+        passed=0,
+        failed=0,
+        skipped=1,
+        metrics={},
+        errors=[],
+    )
+    output = {
+        "schema_version": 1,
+        "suite": SUITE,
+        "service": SERVICE,
+        "summary": summary,
+        "cases_path": str(cases_path),
+        "skipped": {
+            "reason": reason,
+        },
+        "case_results": [],
+        "notes": [
+            "The report only observes existing text filtering logic and does not write feedback logs.",
+        ],
+    }
+    write_report(out_path, output)
+    print(f"[SKIP] {reason}")
+    print(json.dumps(summary, ensure_ascii=False))
+    print(f"report={out_path}")
+
+
+def load_text_filter_service(out_path: Path, cases_path: Path):
+    try:
+        from text_filtering import service as text_filter_service
+    except ModuleNotFoundError as exc:
+        write_skipped_report(out_path, f"text filtering dependency is missing: {exc.name}", cases_path)
+        raise SystemExit(0) from exc
+    except Exception as exc:
+        write_skipped_report(out_path, f"text filtering service import failed: {type(exc).__name__}: {exc}", cases_path)
+        raise SystemExit(0) from exc
+
+    readiness = text_filter_service.get_text_filter_readiness()
+    if readiness.get("status") != "ready":
+        write_skipped_report(out_path, f"text filter model is not ready: {readiness}", cases_path)
+        raise SystemExit(0)
+
+    return text_filter_service
+
+
+def evaluate_case(case: dict[str, Any], text_filter_service) -> dict[str, Any]:
+    text = str(case.get("text", "") or "")
+    expected_has_profanity = bool(case.get("expected", {}).get("has_profanity"))
+    labels = text_filter_service.analyze_text_labels(text)
+    actual_has_profanity = any(label == "비속어" for label in labels)
+    passed = actual_has_profanity == expected_has_profanity
+
+    errors: list[str] = []
+    if not passed:
+        if actual_has_profanity:
+            errors.append("false_positive")
+        else:
+            errors.append("false_negative")
+
+    return {
+        "id": case.get("id"),
+        "category": case.get("category"),
+        "text": text,
+        "expected": {
+            "has_profanity": expected_has_profanity,
+        },
+        "actual": {
+            "has_profanity": actual_has_profanity,
+            "labels": labels,
+        },
+        "status": "passed" if passed else "failed",
+        "errors": errors,
+    }
+
+
+def aggregate_metrics(case_results: list[dict[str, Any]]) -> dict[str, Any]:
+    total = len(case_results)
+    if total == 0:
+        return {}
+
+    passed = sum(1 for result in case_results if result["status"] == "passed")
+    false_positive_count = sum(1 for result in case_results if "false_positive" in result.get("errors", []))
+    false_negative_count = sum(1 for result in case_results if "false_negative" in result.get("errors", []))
+
+    by_category: dict[str, dict[str, Any]] = {}
+    for result in case_results:
+        category = str(result.get("category", "") or "uncategorized")
+        bucket = by_category.setdefault(category, {"total": 0, "passed": 0, "failed": 0})
+        bucket["total"] += 1
+        if result["status"] == "passed":
+            bucket["passed"] += 1
+        else:
+            bucket["failed"] += 1
+
+    for bucket in by_category.values():
+        bucket["pass_rate"] = round(bucket["passed"] / bucket["total"], 4) if bucket["total"] else 0.0
+
+    pass_rate = round(passed / total, 4)
+    return {
+        "false_positive_count": false_positive_count,
+        "false_negative_count": false_negative_count,
+        "pass_rate": pass_rate,
+        "ml_filter_pass_rate": pass_rate,
+        "rule_filter_pass_rate": None,
+        "rule_endpoint_pass_rate": pass_rate,
+        "by_category": by_category,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Write a text filtering quality report")
+    ap.add_argument("--cases", default=str(DEFAULT_CASES_PATH), help="golden text filtering cases path")
+    ap.add_argument("--out", default=str(DEFAULT_REPORT_PATH), help="output report path")
+    ap.add_argument("--validate-only", action="store_true", help="validate golden cases without loading the model")
+    ap.add_argument("--strict", action="store_true", help="return a non-zero exit code when evaluated cases fail")
+    args = ap.parse_args()
+
+    cases_path = Path(args.cases)
+    out_path = Path(args.out)
+    cases = load_cases(cases_path)
+    validation_errors = validate_cases(cases)
+
+    if validation_errors:
+        summary = make_summary(
+            status="failed",
+            total=len(cases),
+            passed=0,
+            failed=len(validation_errors),
+            skipped=0,
+            metrics={},
+            errors=validation_errors,
+        )
+        output = {
+            "schema_version": 1,
+            "suite": SUITE,
+            "service": SERVICE,
+            "summary": summary,
+            "cases_path": str(cases_path),
+            "case_results": [],
+        }
+        write_report(out_path, output)
+        for error in validation_errors:
+            print(f"[FAIL] {error}")
+        print(json.dumps(summary, ensure_ascii=False))
+        print(f"report={out_path}")
+        return 1
+
+    if args.validate_only:
+        summary = make_summary(
+            status="passed",
+            total=len(cases),
+            passed=len(cases),
+            failed=0,
+            skipped=0,
+            metrics={"validated_case_count": len(cases)},
+            errors=[],
+        )
+        output = {
+            "schema_version": 1,
+            "suite": SUITE,
+            "service": SERVICE,
+            "summary": summary,
+            "cases_path": str(cases_path),
+            "case_results": [],
+        }
+        write_report(out_path, output)
+        print("[OK] text filtering quality cases validated")
+        print(json.dumps(summary, ensure_ascii=False))
+        print(f"report={out_path}")
+        return 0
+
+    text_filter_service = load_text_filter_service(out_path, cases_path)
+    case_results = [evaluate_case(case, text_filter_service) for case in cases]
+    errors = [
+        f"{result['id']}:{error}"
+        for result in case_results
+        for error in result.get("errors", [])
+    ]
+    failed = sum(1 for result in case_results if result["status"] == "failed")
+    passed = len(case_results) - failed
+    summary = make_summary(
+        status="failed" if failed else "passed",
+        total=len(case_results),
+        passed=passed,
+        failed=failed,
+        skipped=0,
+        metrics=aggregate_metrics(case_results),
+        errors=errors,
+    )
+    output = {
+        "schema_version": 1,
+        "suite": SUITE,
+        "service": SERVICE,
+        "summary": summary,
+        "cases_path": str(cases_path),
+        "case_results": case_results,
+        "notes": [
+            "This report calls analyze_text_labels() only, so test cases are not appended to data/bad_text_sample.txt.",
+            "rule_endpoint_pass_rate is reported for the current API contract, which uses the shared ML-backed analyzer.",
+        ],
+    }
+    write_report(out_path, output)
+
+    if failed:
+        for error in errors:
+            print(f"[FAIL] {error}")
+        print(json.dumps(summary, ensure_ascii=False))
+        print(f"report={out_path}")
+        return 1 if args.strict else 0
+
+    print("[OK] text filtering quality report")
+    print(json.dumps(summary, ensure_ascii=False))
+    print(f"report={out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/regression/text_filtering/text_filter_quality_cases.json
+++ b/tests/regression/text_filtering/text_filter_quality_cases.json
@@ -1,0 +1,44 @@
+{
+  "cases": [
+    {
+      "id": "clear_korean_profanity_01",
+      "category": "clear_korean_profanity",
+      "text": "이런 씨발 같은 상황은 너무 화가 납니다.",
+      "expected": {
+        "has_profanity": true
+      }
+    },
+    {
+      "id": "normal_sentence_01",
+      "category": "normal_sentence",
+      "text": "오늘 수업 자료를 확인하고 과제를 제출했습니다.",
+      "expected": {
+        "has_profanity": false
+      }
+    },
+    {
+      "id": "normal_sentence_02",
+      "category": "normal_sentence",
+      "text": "동아리 모집 안내를 보고 친구와 함께 신청했습니다.",
+      "expected": {
+        "has_profanity": false
+      }
+    },
+    {
+      "id": "english_profanity_01",
+      "category": "english_profanity",
+      "text": "That was a shit idea.",
+      "expected": {
+        "has_profanity": true
+      }
+    },
+    {
+      "id": "korean_variant_spacing_01",
+      "category": "korean_variant_spacing",
+      "text": "시 발 이라고 띄어 써도 상대에게 불쾌감을 줄 수 있습니다.",
+      "expected": {
+        "has_profanity": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## 🎯 배경

- 텍스트 필터링 품질을 정기적으로 확인할 수 있도록 기능별 회귀 리포트 자동화가 필요합니다.
- 기존 API/필터 판정 로직은 변경하지 않고, 현재 동작을 관찰하는 방식으로 false positive/false negative를 기록합니다.

## 🔍 주요 내용

- `tests/regression/text_filtering/` 아래 텍스트 필터링 품질 리포트 스크립트와 golden case를 추가했습니다.
- 기본 리포트 경로를 `tests/reports/text_filtering/text_filter_quality_report.json`로 설정했습니다.
- `false_positive_count`, `false_negative_count`, `pass_rate`, `ml_filter_pass_rate`, `rule_endpoint_pass_rate` 지표를 출력합니다.
- 품질 실패를 게이트로 강제할 수 있도록 `--strict` 옵션을 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 변경 요약

텍스트 필터링 품질을 자동으로 감시하는 회귀 테스트 시스템이 추가되었습니다. 5개의 테스트 케이스와 품질 리포팅 스크립트로 오탐·미탐·통과율 등을 추적하며, 기존 필터 로직에는 변경이 없이 현재 동작을 관찰하는 방식입니다.

## 주요 변경점

- `tests/regression/text_filtering/` 디렉토리 신설 및 README에 문서화
- `text_filter_quality_cases.json`: 한글 욕설, 영어 욕설, 변형 표현 등 5개 테스트 케이스
- `check_text_filter_quality_report.py`: 케이스 검증, 모델 평가, 지표 집계하는 리포팅 스크립트
- 추적 지표: `false_positive_count`, `false_negative_count`, `pass_rate`, 카테고리별 통과율
- `--strict` 옵션으로 품질 실패 시 종료코드 1로 게이팅 가능
- 모델 미로딩 시 스킵 처리로 CI 환경 호환성 확보

## 주의/리스크

- 모델 의존성이 없을 때 테스트가 스킵되므로, 통합 테스트 환경에서 실제 평가 여부 확인 필요
- 기대값이 현재 필터 동작에 기반하므로, 향후 필터 개선 시 케이스 재검증 필요
- `--strict` 미사용 시 품질 저하가 기본적으로 무시됨 (CI 파이프라인에서 명시적 사용 필수)

## 다음 액션

- CI/CD 파이프라인에 `--strict` 옵션으로 스크립트 통합
- 테스트 케이스의 커버리지 및 기대값 타당성 검토
- 향후 품질 기준선(threshold) 설정 및 알림 체계 수립
<!-- end of auto-generated comment: release notes by coderabbit.ai -->