### PR TITLE
chore: standardize runtime quality logs

### DIFF
--- a/LLM/OSS/llm_client.py
+++ b/LLM/OSS/llm_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from typing import Optional
@@ -7,7 +8,13 @@ from typing import Optional
 from openai import OpenAI
 
 from core.exceptions import ConfigurationError
-from core.logging import get_logger
+from core.logging import (
+    RuntimeComponent,
+    RuntimeOperation,
+    RuntimeStatus,
+    get_logger,
+    runtime_log_message,
+)
 from core.settings import get_settings
 
 
@@ -52,6 +59,7 @@ def call_oss(messages: list[dict[str, str]], **kwargs) -> str:
     except ConfigurationError:
         raise
 
+    start = time.monotonic()
     try:
         response = client.chat.completions.create(
             model=settings.oss_model,
@@ -61,10 +69,56 @@ def call_oss(messages: list[dict[str, str]], **kwargs) -> str:
             timeout=kwargs.get("timeout", 45),
         )
         if not response.choices:
+            logger.warning(
+                runtime_log_message(
+                    "chatbot_llm_runtime",
+                    component=RuntimeComponent.CHATBOT,
+                    operation=RuntimeOperation.LLM,
+                    status=RuntimeStatus.FALLBACK,
+                    duration_ms=int((time.monotonic() - start) * 1000),
+                    result_count=0,
+                    fallback=True,
+                    fallback_reason="empty_choices",
+                    error_code=None,
+                    model=settings.oss_model,
+                    empty_response=True,
+                )
+            )
             logger.warning("oss_call_empty_choices")
             return ""
-        return (response.choices[0].message.content or "").strip()
+        output = (response.choices[0].message.content or "").strip()
+        logger.info(
+            runtime_log_message(
+                "chatbot_llm_runtime",
+                component=RuntimeComponent.CHATBOT,
+                operation=RuntimeOperation.LLM,
+                status=RuntimeStatus.SUCCESS if output else RuntimeStatus.FALLBACK,
+                duration_ms=int((time.monotonic() - start) * 1000),
+                result_count=1 if output else 0,
+                fallback=not bool(output),
+                fallback_reason=None if output else "empty_response",
+                error_code=None,
+                model=settings.oss_model,
+                empty_response=not bool(output),
+            )
+        )
+        return output
     except Exception:
+        logger.warning(
+            runtime_log_message(
+                "chatbot_llm_runtime",
+                component=RuntimeComponent.CHATBOT,
+                operation=RuntimeOperation.LLM,
+                status=RuntimeStatus.FAILED,
+                duration_ms=int((time.monotonic() - start) * 1000),
+                result_count=0,
+                fallback=True,
+                fallback_reason="llm_exception",
+                error_code="oss_call_failed",
+                model=settings.oss_model,
+                empty_response=True,
+            )
+        )
         logger.warning("oss_call_failed", exc_info=True)
         return ""
 

--- a/LLM/OSS/service.py
+++ b/LLM/OSS/service.py
@@ -8,7 +8,13 @@ import httpx
 from cachetools import TTLCache
 from pydantic import BaseModel
 
-from core.logging import get_logger
+from core.logging import (
+    RuntimeComponent,
+    RuntimeOperation,
+    RuntimeStatus,
+    get_logger,
+    runtime_log_message,
+)
 from core.settings import get_settings
 from LLM.OSS.chat_log_store import log_chatbot
 from LLM.OSS.formatter import (
@@ -52,12 +58,23 @@ class ChatReq(BaseModel):
     engine: Optional[str] = None
 
 
+def _query_hash(user_text: str) -> str:
+    return hashlib.sha256((user_text or "").encode("utf-8")).hexdigest()[:12]
+
+
+def _elapsed_ms(start: float) -> int:
+    return int((time.monotonic() - start) * 1000)
+
+
+def _is_direct_answer_route(result: ToolResult | None) -> bool:
+    return bool(result and result.name in {"metadata_direct_answer", "confident_search_answer"})
+
+
 def _log_tool_route(user_text: str, mode: str, stage: str, result: ToolResult) -> None:
-    query_hash = hashlib.sha256((user_text or "").encode("utf-8")).hexdigest()[:12]
     logger.info(
         "chatbot_tool_route query_hash=%s mode=%s stage=%s tool=%s engine=%s confidence=%.2f "
         "llm_required=%s has_text=%s reason=%s",
-        query_hash,
+        _query_hash(user_text),
         mode,
         stage,
         result.name,
@@ -66,6 +83,40 @@ def _log_tool_route(user_text: str, mode: str, stage: str, result: ToolResult) -
         result.llm_required,
         bool(result.text.strip()),
         result.reason,
+    )
+
+
+def _log_chatbot_summary(
+    user_text: str,
+    start: float,
+    mode: str,
+    response: dict,
+    *,
+    cache_hit: bool = False,
+    direct_answer_route: bool = False,
+    fallback: bool = False,
+    fallback_reason: str | None = None,
+    status: RuntimeStatus = RuntimeStatus.SUCCESS,
+    error_code: str | None = None,
+) -> None:
+    text = str(response.get("text", "") or "")
+    logger.info(
+        runtime_log_message(
+            "chatbot_request_summary",
+            component=RuntimeComponent.CHATBOT,
+            operation=RuntimeOperation.REQUEST,
+            status=status,
+            duration_ms=_elapsed_ms(start),
+            result_count=1 if text else 0,
+            fallback=fallback,
+            fallback_reason=fallback_reason,
+            error_code=error_code,
+            query_hash=_query_hash(user_text),
+            mode=mode,
+            engine=response.get("engine", "none"),
+            cache_hit=cache_hit,
+            direct_answer_route=direct_answer_route,
+        )
     )
 
 
@@ -126,17 +177,23 @@ async def chat_with_oss(req: ChatReq) -> dict:
     if await should_block_profanity(user_text):
         latency = int((time.monotonic() - start) * 1000)
         log_chatbot(user_text, "guard", PROFANITY_GUARD_TEXT, None, False, latency)
-        return {"engine": "guard", "text": PROFANITY_GUARD_TEXT}
+        response = {"engine": "guard", "text": PROFANITY_GUARD_TEXT}
+        _log_chatbot_summary(user_text, start, "guard", response)
+        return response
 
     if GOVERNANCE_REMOVE_RE.search(user_text) and GOVERNANCE_TARGET_RE.search(user_text):
-        return {
+        response = {
             "engine": "guard",
             "text": "해당 요청은 도움을 드리기 어려워요; 공식 절차나 문의는 학생자치기구 페이지의 연락처를 이용해 주세요.",
         }
+        _log_chatbot_summary(user_text, start, "guard", response)
+        return response
 
     mode = req.engine or decide_mode(user_text)
     if mode == "oss" and len(compact_user_text) <= 2:
-        return {"engine": "greet", "text": "네, 무엇을 도와드릴까요?"}
+        response = {"engine": "greet", "text": "네, 무엇을 도와드릴까요?"}
+        _log_chatbot_summary(user_text, start, mode, response)
+        return response
     normalized = " ".join(user_text.strip().split())
     relative_date_scope = ""
     if looks_like_schedule(user_text) and any(keyword in user_text for keyword in RELATIVE_DATE_KEYWORDS):
@@ -151,46 +208,73 @@ async def chat_with_oss(req: ChatReq) -> dict:
             latency = int((time.monotonic() - start) * 1000)
             response = dict(cached)
             log_chatbot(user_text, mode, response.get("text", ""), response.get("url"), True, latency)
+            _log_chatbot_summary(user_text, start, mode, response, cache_hit=True)
             return response
 
-    def cache_and_return(response: dict) -> dict:
+    def cache_and_return(
+        response: dict,
+        *,
+        direct_answer_route: bool = False,
+        fallback: bool = False,
+        fallback_reason: str | None = None,
+    ) -> dict:
         if mode not in _CACHE_SKIP:
             cache = _CACHE_RULE_BOOK if mode == "rule_book" else _CACHE_GENERAL
             with _cache_lock:
                 cache[cache_key] = response
         latency = int((time.monotonic() - start) * 1000)
         log_chatbot(user_text, mode, response.get("text", ""), response.get("url"), False, latency)
+        _log_chatbot_summary(
+            user_text,
+            start,
+            mode,
+            response,
+            direct_answer_route=direct_answer_route,
+            fallback=fallback,
+            fallback_reason=fallback_reason,
+        )
         return response
 
     if mode == "rule_book":
         answer = await run_rule_book(user_text)
         return cache_and_return({"engine": "rule_book", "text": answer})
     if mode == "greet":
-        return {"engine": "greet", "text": "안녕하세요, 무엇을 도와드릴까요?"}
+        response = {"engine": "greet", "text": "안녕하세요, 무엇을 도와드릴까요?"}
+        _log_chatbot_summary(user_text, start, mode, response)
+        return response
     if mode == "whoami":
-        return {"engine": "whoami", "text": f"{settings.service_name}의 {settings.bot_name}입니다."}
+        response = {"engine": "whoami", "text": f"{settings.service_name}의 {settings.bot_name}입니다."}
+        _log_chatbot_summary(user_text, start, mode, response)
+        return response
     if mode == "relation":
-        return {
+        response = {
             "engine": "relation",
             "text": f"우리는 {settings.org_name} 정보를 함께 해결하는 대화 파트너이고, 저는 {settings.service_name}의 {settings.bot_name}입니다.",
         }
+        _log_chatbot_summary(user_text, start, mode, response)
+        return response
 
     tool_result = run_mode_tools(mode, user_text)
     _log_tool_route(user_text, mode, "mode_tools", tool_result)
     if tool_result.resolved:
-        return cache_and_return(tool_result.to_response())
+        return cache_and_return(tool_result.to_response(), direct_answer_route=_is_direct_answer_route(tool_result))
 
     grounded_fallback: ToolResult | None = None
     if mode == "oss":
         fast_path = run_oss_fast_path_tools(user_text)
         _log_tool_route(user_text, mode, "oss_fast_path", fast_path)
         if fast_path.resolved:
-            return cache_and_return(fast_path.to_response())
+            return cache_and_return(fast_path.to_response(), direct_answer_route=_is_direct_answer_route(fast_path))
 
         grounded_fallback = run_final_fallback_tools(mode, user_text)
         _log_tool_route(user_text, mode, "oss_grounded_fallback", grounded_fallback)
         if grounded_fallback.resolved:
-            return cache_and_return(grounded_fallback.to_response())
+            return cache_and_return(
+                grounded_fallback.to_response(),
+                direct_answer_route=_is_direct_answer_route(grounded_fallback),
+                fallback=True,
+                fallback_reason=grounded_fallback.reason,
+            )
 
         if grounded_fallback.llm_required and grounded_fallback.text.strip():
             output = await call_oss_async(
@@ -210,7 +294,16 @@ async def chat_with_oss(req: ChatReq) -> dict:
             if output:
                 latency = int((time.monotonic() - start) * 1000)
                 log_chatbot(user_text, "oss", output, None, False, latency)
-                return {"engine": "oss", "text": output}
+                response = {"engine": "oss", "text": output}
+                _log_chatbot_summary(
+                    user_text,
+                    start,
+                    mode,
+                    response,
+                    fallback=True,
+                    fallback_reason=grounded_fallback.reason,
+                )
+                return response
 
             fallback = run_empty_oss_fallback_tools(user_text)
             _log_tool_route(user_text, mode, "oss_grounded_empty_fallback", fallback)
@@ -218,18 +311,36 @@ async def chat_with_oss(req: ChatReq) -> dict:
                 response = fallback.to_response()
                 latency = int((time.monotonic() - start) * 1000)
                 log_chatbot(user_text, response["engine"], response["text"], response.get("url"), False, latency)
+                _log_chatbot_summary(
+                    user_text,
+                    start,
+                    mode,
+                    response,
+                    direct_answer_route=_is_direct_answer_route(fallback),
+                    fallback=True,
+                    fallback_reason=fallback.reason,
+                )
                 return response
 
             if len(user_text) <= 2 or GREETING_RE.search(user_text):
                 latency = int((time.monotonic() - start) * 1000)
                 output = "안녕하세요, 무엇을 도와드릴까요?"
                 log_chatbot(user_text, "greet", output, None, False, latency)
-                return {"engine": "greet", "text": output}
+                response = {"engine": "greet", "text": output}
+                _log_chatbot_summary(
+                    user_text,
+                    start,
+                    mode,
+                    response,
+                    fallback=True,
+                    fallback_reason="empty_llm_greeting",
+                )
+                return response
 
             return cache_and_return({
                 "engine": "oss",
                 "text": "관련 근거를 충분히 확인하지 못했어요. 질문을 조금 더 구체적으로 다시 입력해 주세요.",
-            })
+            }, fallback=True, fallback_reason="grounded_llm_empty")
 
         output = await call_oss_async(messages_for_oss)
         if not any(keyword in user_text for keyword in ("연락처", "전화", "번호", "문의")) and not any(keyword in user_text for keyword in COUNCIL_KWS):
@@ -242,6 +353,15 @@ async def chat_with_oss(req: ChatReq) -> dict:
                 response = fallback.to_response()
                 latency = int((time.monotonic() - start) * 1000)
                 log_chatbot(user_text, response["engine"], response["text"], response.get("url"), False, latency)
+                _log_chatbot_summary(
+                    user_text,
+                    start,
+                    mode,
+                    response,
+                    direct_answer_route=_is_direct_answer_route(fallback),
+                    fallback=True,
+                    fallback_reason=fallback.reason,
+                )
                 return response
 
             if len(user_text) <= 2 or GREETING_RE.search(user_text):
@@ -250,18 +370,32 @@ async def chat_with_oss(req: ChatReq) -> dict:
         if output:
             latency = int((time.monotonic() - start) * 1000)
             log_chatbot(user_text, "oss", output, None, False, latency)
-            return {"engine": "oss", "text": output}
+            response = {"engine": "oss", "text": output}
+            _log_chatbot_summary(
+                user_text,
+                start,
+                mode,
+                response,
+                fallback=output == "안녕하세요, 무엇을 도와드릴까요?",
+                fallback_reason="empty_llm_greeting" if output == "안녕하세요, 무엇을 도와드릴까요?" else None,
+            )
+            return response
         
         if grounded_fallback is not None and not grounded_fallback.text.strip():
             return cache_and_return({
                 "engine": "oss",
                 "text": "관련 근거를 충분히 확인하지 못했어요. 질문을 조금 더 구체적으로 다시 입력해주세요."
-            })
+            }, fallback=True, fallback_reason="empty_rag_context")
 
     fallback = grounded_fallback or run_final_fallback_tools(mode, user_text)
     _log_tool_route(user_text, mode, "final_fallback", fallback)
     if fallback.resolved:
-        return cache_and_return(fallback.to_response())
+        return cache_and_return(
+            fallback.to_response(),
+            direct_answer_route=_is_direct_answer_route(fallback),
+            fallback=True,
+            fallback_reason=fallback.reason,
+        )
 
     fused = await call_oss_async(
         [
@@ -281,4 +415,13 @@ async def chat_with_oss(req: ChatReq) -> dict:
 
     latency = int((time.monotonic() - start) * 1000)
     log_chatbot(user_text, mode, fused, None, False, latency)
-    return {"engine": mode, "text": fused}
+    response = {"engine": mode, "text": fused}
+    _log_chatbot_summary(
+        user_text,
+        start,
+        mode,
+        response,
+        fallback=True,
+        fallback_reason=fallback.reason if fallback else None,
+    )
+    return response

--- a/LLM/sub_model/query_index.py
+++ b/LLM/sub_model/query_index.py
@@ -1,9 +1,17 @@
 import re
+import time
 from functools import lru_cache
 
 import numpy as np
 import pandas as pd
 
+from core.logging import (
+    RuntimeComponent,
+    RuntimeOperation,
+    RuntimeStatus,
+    get_logger,
+    runtime_log_message,
+)
 from LLM.patterns import (
     BOARD_URL_PATTERN,
     DASH_CHARS_PATTERN,
@@ -20,6 +28,9 @@ from LLM.patterns import (
     UNIT_SUFFIX_RE,
 )
 from LLM.sub_model.query_index_loader import load_query_index_resources
+
+
+logger = get_logger(__name__)
 
 # 졸업학점 관련 키워드 복원 (학교 기본 정보 포함)
 GRAD_KWS = ["졸업학점", "졸업 학점", "졸업요건", "졸업요구학점", "이수학점", "졸업 이수학점"]
@@ -461,6 +472,7 @@ model        = _index_resources.model
 search_df    = _index_resources.search_df
 tokenize_kor = _index_resources.tokenizer
 bm25         = _index_resources.bm25
+bm25_fallback_tier = _index_resources.bm25_fallback_tier
 
 @lru_cache(maxsize=512)
 def embed_query(q: str):
@@ -474,54 +486,90 @@ def _minmax(x):
 # 최신성 점수 함수 제거됨 (학교 기본 정보만 제공)
 
 def hybrid_search(query, top_k=8, alpha=DEFAULT_DENSE_WEIGHT, contact_boost=CONTACT_DOC_BOOST):
+    start = time.monotonic()
     query = _normalize_doit_query(query)
 
-    qv = embed_query(query)
-    dense_raw = embeddings @ qv
-    bm25_raw  = bm25.get_scores(tokenize_kor(query))
-    base = alpha * _minmax(dense_raw) + (1 - alpha) * _minmax(bm25_raw)
+    try:
+        qv = embed_query(query)
+        dense_raw = embeddings @ qv
+        bm25_raw  = bm25.get_scores(tokenize_kor(query))
+        base = alpha * _minmax(dense_raw) + (1 - alpha) * _minmax(bm25_raw)
 
-    bonus = np.zeros(len(search_df))
-    doc_type = search_df["doc_type"].astype(str)
-    query_text = query or ""
+        bonus = np.zeros(len(search_df))
+        doc_type = search_df["doc_type"].astype(str)
+        query_text = query or ""
 
-    if any(k in query_text for k in CONTACT_KWS):
-        is_contact = (doc_type == "contact").astype(float).to_numpy()
-        phone_text = search_df["phone"].astype(str).str.strip()
-        email_text = search_df["email"].astype(str).str.strip()
-        has_phone = (
-            search_df["has_phone"].astype(bool)
-            | (phone_text.ne("") & phone_text.ne("없음"))
-        ).astype(float).to_numpy()
-        has_email = (
-            search_df["has_email"].astype(bool)
-            | (email_text.ne("") & email_text.ne("없음"))
-        ).astype(float).to_numpy()
-        bonus = contact_boost * (is_contact + PHONE_EMAIL_BONUS_RATIO*has_phone + PHONE_EMAIL_BONUS_RATIO*has_email)
+        if any(k in query_text for k in CONTACT_KWS):
+            is_contact = (doc_type == "contact").astype(float).to_numpy()
+            phone_text = search_df["phone"].astype(str).str.strip()
+            email_text = search_df["email"].astype(str).str.strip()
+            has_phone = (
+                search_df["has_phone"].astype(bool)
+                | (phone_text.ne("") & phone_text.ne("없음"))
+            ).astype(float).to_numpy()
+            has_email = (
+                search_df["has_email"].astype(bool)
+                | (email_text.ne("") & email_text.ne("없음"))
+            ).astype(float).to_numpy()
+            bonus = contact_boost * (is_contact + PHONE_EMAIL_BONUS_RATIO*has_phone + PHONE_EMAIL_BONUS_RATIO*has_email)
 
-    if _looks_like_grad_query(query_text) or POLICY_QUERY_RE.search(query_text):
-        is_policy = doc_type.isin(["policy", "table_like"]).astype(float).to_numpy()
-        has_policy = search_df["has_policy_keyword"].astype(float).to_numpy()
-        has_credit = search_df["has_credit"].astype(float).to_numpy()
-        bonus += 0.08 * is_policy + 0.05 * has_policy + 0.12 * has_credit
+        if _looks_like_grad_query(query_text) or POLICY_QUERY_RE.search(query_text):
+            is_policy = doc_type.isin(["policy", "table_like"]).astype(float).to_numpy()
+            has_policy = search_df["has_policy_keyword"].astype(float).to_numpy()
+            has_credit = search_df["has_credit"].astype(float).to_numpy()
+            bonus += 0.08 * is_policy + 0.05 * has_policy + 0.12 * has_credit
 
-    if INTRO_QUERY_RE.search(query_text):
-        is_intro = doc_type.isin(["intro", "department", "history"]).astype(float).to_numpy()
-        bonus += 0.05 * is_intro
+        if INTRO_QUERY_RE.search(query_text):
+            is_intro = doc_type.isin(["intro", "department", "history"]).astype(float).to_numpy()
+            bonus += 0.05 * is_intro
 
-    if not PRIVACY_QUERY_RE.search(query_text):
-        is_privacy = doc_type.eq("privacy").astype(float).to_numpy()
-        is_old_privacy = search_df["is_privacy_old"].astype(float).to_numpy()
-        bonus -= 0.12 * is_privacy + 0.18 * is_old_privacy
+        if not PRIVACY_QUERY_RE.search(query_text):
+            is_privacy = doc_type.eq("privacy").astype(float).to_numpy()
+            is_old_privacy = search_df["is_privacy_old"].astype(float).to_numpy()
+            bonus -= 0.12 * is_privacy + 0.18 * is_old_privacy
 
-    scores = base + bonus
-    out = search_df.copy()
-    out["score"] = scores
-    if "url" in out.columns:
-        rep_idx = out.groupby(["url","doc_type"], dropna=False)["score"].idxmax()
-        out = out.loc[rep_idx]
-    out = out.sort_values(["score"], ascending=[False], na_position="last").head(top_k)
-    return out.reset_index(drop=True)
+        scores = base + bonus
+        out = search_df.copy()
+        out["score"] = scores
+        if "url" in out.columns:
+            rep_idx = out.groupby(["url","doc_type"], dropna=False)["score"].idxmax()
+            out = out.loc[rep_idx]
+        out = out.sort_values(["score"], ascending=[False], na_position="last").head(top_k)
+        result = out.reset_index(drop=True)
+    except Exception:
+        logger.info(
+            runtime_log_message(
+                "chatbot_retrieval_runtime",
+                component=RuntimeComponent.CHATBOT,
+                operation=RuntimeOperation.RETRIEVAL,
+                status=RuntimeStatus.FAILED,
+                duration_ms=int((time.monotonic() - start) * 1000),
+                result_count=0,
+                fallback=True,
+                fallback_reason="retrieval_exception",
+                error_code="retrieval_failed",
+                requested_top_k=top_k,
+                bm25_fallback_tier=bm25_fallback_tier,
+            )
+        )
+        raise
+
+    logger.info(
+        runtime_log_message(
+            "chatbot_retrieval_runtime",
+            component=RuntimeComponent.CHATBOT,
+            operation=RuntimeOperation.RETRIEVAL,
+            status=RuntimeStatus.SUCCESS,
+            duration_ms=int((time.monotonic() - start) * 1000),
+            result_count=len(result),
+            fallback=bm25_fallback_tier != "pickle",
+            fallback_reason=bm25_fallback_tier,
+            error_code=None,
+            requested_top_k=top_k,
+            bm25_fallback_tier=bm25_fallback_tier,
+        )
+    )
+    return result
 
 def build_answer(query, top_k=6):
     direct = _doit_direct_answer(query)

--- a/LLM/sub_model/query_index_loader.py
+++ b/LLM/sub_model/query_index_loader.py
@@ -99,13 +99,26 @@ def load_bm25(path: Path, tok_path: Path, search_df: pd.DataFrame, tokenizer) ->
             )
 
     if tok_path.exists():
-        fallback_tier = "tokenized_corpus"
-        logger.warning(
-            "query_index_bm25_rebuild fallback=tokenized_corpus bm25_file=%s tokenized_file=%s",
-            path.name,
-            tok_path.name,
-        )
-        tokenized_corpus = load_json_gz(str(tok_path))
+        try:
+            fallback_tier = "tokenized_corpus"
+            logger.warning(
+                "query_index_bm25_rebuild fallback=tokenized_corpus bm25_file=%s tokenized_file=%s",
+                path.name,
+                tok_path.name,
+            )
+            tokenized_corpus = load_json_gz(str(tok_path))
+        except Exception as exc:
+            fallback_tier = "runtime_tokenize"
+            logger.warning(
+                "query_index_bm25_tokenized_load_failed fallback=runtime_tokenize bm25_file=%s tokenized_file=%s error=%s",
+                path.name,
+                tok_path.name,
+                type(exc).__name__,
+            )
+            tokenized_corpus = [
+                tokenizer(t)
+                for t in search_df["text_for_bm25"].astype(str).tolist()
+            ]
     else:
         fallback_tier = "runtime_tokenize"
         logger.warning(

--- a/LLM/sub_model/query_index_loader.py
+++ b/LLM/sub_model/query_index_loader.py
@@ -43,6 +43,7 @@ class QueryIndexResources:
     search_df: pd.DataFrame
     tokenizer: Callable[[str], list[str]]
     bm25: BM25Okapi
+    bm25_fallback_tier: str
     model_name: str
     model: SentenceTransformer
 
@@ -84,9 +85,14 @@ def load_embeddings(path: Path) -> np.ndarray:
     return embeddings / row_norms
 
 
+def resolve_bm25_fallback_tier(tok_path: Path) -> str:
+    return "tokenized_corpus" if tok_path.exists() else "runtime_tokenize"
+
+
 def load_bm25(path: Path, tok_path: Path, search_df: pd.DataFrame, tokenizer) -> BM25Okapi:
 
-    if tok_path.exists():
+    fallback_tier = resolve_bm25_fallback_tier(tok_path)
+    if fallback_tier == "tokenized_corpus":
         logger.warning(
             "query_index_bm25_rebuild fallback=tokenized_corpus bm25_file=%s tokenized_file=%s",
             path.name,
@@ -122,6 +128,7 @@ def load_query_index_resources(
         search_df=search_df,
         tokenizer=tokenizer,
         bm25=load_bm25(paths.bm25_path, paths.tok_path, search_df, tokenizer),
+        bm25_fallback_tier=resolve_bm25_fallback_tier(paths.tok_path),
         model_name=model_name,
         model=SentenceTransformer(model_name),
     )

--- a/LLM/sub_model/query_index_loader.py
+++ b/LLM/sub_model/query_index_loader.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pickle
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
@@ -85,14 +86,20 @@ def load_embeddings(path: Path) -> np.ndarray:
     return embeddings / row_norms
 
 
-def resolve_bm25_fallback_tier(tok_path: Path) -> str:
-    return "tokenized_corpus" if tok_path.exists() else "runtime_tokenize"
+def load_bm25(path: Path, tok_path: Path, search_df: pd.DataFrame, tokenizer) -> tuple[BM25Okapi, str]:
+    if path.exists():
+        try:
+            with open(path, "rb") as f:
+                return pickle.load(f), "pickle"
+        except Exception as exc:
+            logger.warning(
+                "query_index_bm25_pickle_load_failed fallback=tokenized_or_runtime bm25_file=%s error=%s",
+                path.name,
+                type(exc).__name__,
+            )
 
-
-def load_bm25(path: Path, tok_path: Path, search_df: pd.DataFrame, tokenizer) -> BM25Okapi:
-
-    fallback_tier = resolve_bm25_fallback_tier(tok_path)
-    if fallback_tier == "tokenized_corpus":
+    if tok_path.exists():
+        fallback_tier = "tokenized_corpus"
         logger.warning(
             "query_index_bm25_rebuild fallback=tokenized_corpus bm25_file=%s tokenized_file=%s",
             path.name,
@@ -100,6 +107,7 @@ def load_bm25(path: Path, tok_path: Path, search_df: pd.DataFrame, tokenizer) ->
         )
         tokenized_corpus = load_json_gz(str(tok_path))
     else:
+        fallback_tier = "runtime_tokenize"
         logger.warning(
             "query_index_bm25_rebuild fallback=runtime_tokenize bm25_file=%s tokenized_file=%s documents=%s",
             path.name,
@@ -110,7 +118,7 @@ def load_bm25(path: Path, tok_path: Path, search_df: pd.DataFrame, tokenizer) ->
             tokenizer(t)
             for t in search_df["text_for_bm25"].astype(str).tolist()
         ]
-    return BM25Okapi(tokenized_corpus)
+    return BM25Okapi(tokenized_corpus), fallback_tier
 
 
 def load_query_index_resources(
@@ -120,6 +128,7 @@ def load_query_index_resources(
     paths = paths or load_query_index_paths()
     search_df = normalize_search_df_schema(pd.read_parquet(paths.search_df_path))
     tokenizer = get_tokenizer()
+    bm25, bm25_fallback_tier = load_bm25(paths.bm25_path, paths.tok_path, search_df, tokenizer)
 
     return QueryIndexResources(
         paths=paths,
@@ -127,8 +136,8 @@ def load_query_index_resources(
         embeddings=load_embeddings(paths.emb_path),
         search_df=search_df,
         tokenizer=tokenizer,
-        bm25=load_bm25(paths.bm25_path, paths.tok_path, search_df, tokenizer),
-        bm25_fallback_tier=resolve_bm25_fallback_tier(paths.tok_path),
+        bm25=bm25,
+        bm25_fallback_tier=bm25_fallback_tier,
         model_name=model_name,
         model=SentenceTransformer(model_name),
     )

--- a/core/logging/__init__.py
+++ b/core/logging/__init__.py
@@ -1,4 +1,20 @@
 from core.logging.config import configure_logging, get_logger
 from core.logging.middleware import register_request_logging
+from core.logging.runtime import (
+    RUNTIME_LOG_FIELDS,
+    RuntimeComponent,
+    RuntimeOperation,
+    RuntimeStatus,
+    runtime_log_message,
+)
 
-__all__ = ["configure_logging", "get_logger", "register_request_logging"]
+__all__ = [
+    "RUNTIME_LOG_FIELDS",
+    "RuntimeComponent",
+    "RuntimeOperation",
+    "RuntimeStatus",
+    "configure_logging",
+    "get_logger",
+    "register_request_logging",
+    "runtime_log_message",
+]

--- a/core/logging/runtime.py
+++ b/core/logging/runtime.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Final
+
+
+class RuntimeComponent(str, Enum):
+    CHATBOT = "chatbot"
+    OCR = "ocr"
+    TEXT_FILTERING = "text_filtering"
+
+
+class RuntimeOperation(str, Enum):
+    REQUEST = "request"
+    RETRIEVAL = "retrieval"
+    LLM = "llm"
+    GRID_DETECTION = "grid_detection"
+    OCR = "ocr"
+    RULE_FILTER = "rule_filter"
+    ML_FILTER = "ml_filter"
+
+
+class RuntimeStatus(str, Enum):
+    SUCCESS = "success"
+    FAILED = "failed"
+    FALLBACK = "fallback"
+    SKIPPED = "skipped"
+
+
+RUNTIME_LOG_FIELDS: Final[tuple[str, ...]] = (
+    "event",
+    "component",
+    "operation",
+    "status",
+    "duration_ms",
+    "result_count",
+    "fallback",
+    "fallback_reason",
+    "error_code",
+)
+
+
+def _format_log_value(value: Any) -> str:
+    if isinstance(value, Enum):
+        value = value.value
+    if value is None:
+        return "none"
+    if isinstance(value, bool):
+        return str(value).lower()
+    text = str(value).replace("\n", " ").replace("\r", " ").strip()
+    if not text:
+        return "none"
+    return text.replace(" ", "_")
+
+
+def runtime_log_message(event: str, **fields: Any) -> str:
+    ordered_fields = {"event": event, **fields}
+    return " ".join(f"{key}={_format_log_value(value)}" for key, value in ordered_fields.items())

--- a/core/logging/runtime.py
+++ b/core/logging/runtime.py
@@ -50,9 +50,12 @@ def _format_log_value(value: Any) -> str:
     text = str(value).replace("\n", " ").replace("\r", " ").strip()
     if not text:
         return "none"
-    return text.replace(" ", "_")
+    return text.replace(" ", "_").replace("=", ":")
 
 
 def runtime_log_message(event: str, **fields: Any) -> str:
-    ordered_fields = {"event": event, **fields}
-    return " ".join(f"{key}={_format_log_value(value)}" for key, value in ordered_fields.items())
+    all_fields = {"event": event, **fields}
+    ordered_keys = [k for k in RUNTIME_LOG_FIELDS if k in all_fields]
+    extra_keys = [k for k in all_fields.keys() if k not in RUNTIME_LOG_FIELDS]
+    keys = ordered_keys + extra_keys
+    return " ".join(f"{key}={_format_log_value(all_fields[key])}" for key in keys)

--- a/image_analysis/ocr_engine.py
+++ b/image_analysis/ocr_engine.py
@@ -2,6 +2,7 @@ from datetime import time
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Optional
+import logging
 import re
 import time as perf_time
 import cv2
@@ -13,12 +14,14 @@ from core.logging import (
     RuntimeComponent,
     RuntimeOperation,
     RuntimeStatus,
+    configure_logging,
     get_logger,
     runtime_log_message,
 )
 
 
 logger = get_logger(__name__)
+OCR_WORKER_SERVICE_NAME = "main-api"
 
 WEEKDAYS_FILE = Path("data/weekdays.txt")
 TIME_SLOTS_FILE = Path("data/time_slots.txt")
@@ -44,6 +47,15 @@ TRIM_OUTER, TRIM_X_GAP, TRIM_Y_GAP = True, 20, 15
 OCR_THREAD_WORKERS = 8
 LOW_OCR_CONFIDENCE = 55.0
 MAX_REJECTED_CELLS_IN_DIAGNOSTICS = 120
+
+
+def configure_ocr_worker_logging() -> None:
+    configure_logging(OCR_WORKER_SERVICE_NAME)
+
+
+def _ensure_ocr_engine_logging() -> None:
+    if not logging.getLogger().handlers:
+        configure_ocr_worker_logging()
 
 
 def _clean_ocr_lines(text: str) -> List[str]:
@@ -634,6 +646,7 @@ def _extract_schedule_core(
 
 
 def _log_ocr_engine_runtime(diagnostics: Dict[str, Any], schedule_count: int) -> None:
+    _ensure_ocr_engine_logging()
     failure_reason = diagnostics.get("failure_reason")
     ocr = diagnostics.get("ocr", {})
     runtime = diagnostics.get("runtime", {})

--- a/image_analysis/ocr_engine.py
+++ b/image_analysis/ocr_engine.py
@@ -3,11 +3,22 @@ from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Optional
 import re
+import time as perf_time
 import cv2
 import numpy as np
 import pytesseract
 from PIL import Image
 
+from core.logging import (
+    RuntimeComponent,
+    RuntimeOperation,
+    RuntimeStatus,
+    get_logger,
+    runtime_log_message,
+)
+
+
+logger = get_logger(__name__)
 
 WEEKDAYS_FILE = Path("data/weekdays.txt")
 TIME_SLOTS_FILE = Path("data/time_slots.txt")
@@ -412,6 +423,7 @@ def _extract_schedule_core(
     debug_dir: Optional[Path] = None,
     diagnostics_enabled: bool = False,
 ) -> Dict[str, Any]:
+    start = perf_time.monotonic()
     diagnostics: Dict[str, Any] = {
         "image_quality": assess_image_quality(img) if diagnostics_enabled else {},
         "grid": {},
@@ -424,9 +436,15 @@ def _extract_schedule_core(
             "low_confidence_cells": 0,
             "average_confidence": None,
         },
+        "runtime": {
+            "grid_detection_duration_ms": 0,
+            "ocr_duration_ms": 0,
+            "total_duration_ms": 0,
+        },
         "debug_images": {},
     }
 
+    grid_start = perf_time.monotonic()
     base_gray = _make_base_gray(img)
     x_lines, vertical_mask = _vertical_lines(base_gray)
     x_lines = _prune_x_lines(x_lines, base_gray)
@@ -442,6 +460,7 @@ def _extract_schedule_core(
         if len(y_lines) > 2 and (y_lines[-1] - y_lines[-2] < TRIM_Y_GAP):
             y_lines = y_lines[:-1]
 
+    diagnostics["runtime"]["grid_detection_duration_ms"] = int((perf_time.monotonic() - grid_start) * 1000)
     diagnostics["grid"] = {
         "x_line_count": len(x_lines),
         "y_line_count": len(y_lines),
@@ -455,12 +474,16 @@ def _extract_schedule_core(
 
     if len(x_lines) - 1 < 3 or len(y_lines) - 1 < 3:
         diagnostics["failure_reason"] = "insufficient_grid_lines"
+        diagnostics["runtime"]["total_duration_ms"] = int((perf_time.monotonic() - start) * 1000)
+        _log_ocr_engine_runtime(diagnostics, 0)
         return {"schedules": [], "diagnostics": diagnostics}
 
     weekdays = _load_list_from_txt(WEEKDAYS_FILE)
     time_slots = _load_list_from_txt(TIME_SLOTS_FILE)
     if not weekdays or not time_slots:
         diagnostics["failure_reason"] = "missing_weekdays_or_time_slots"
+        diagnostics["runtime"]["total_duration_ms"] = int((perf_time.monotonic() - start) * 1000)
+        _log_ocr_engine_runtime(diagnostics, 0)
         return {"schedules": [], "diagnostics": diagnostics}
 
     tasks: List[bytes] = []
@@ -468,8 +491,7 @@ def _extract_schedule_core(
     for row, col, roi_gray in _iterate_cells_autogrid(base_gray, x_lines, y_lines):
         if row == 0:
             continue
-        if diagnostics_enabled:
-            diagnostics["ocr"]["total_cells"] += 1
+        diagnostics["ocr"]["total_cells"] += 1
         ok, buf = cv2.imencode(".png", roi_gray)
         if not ok:
             if diagnostics_enabled:
@@ -479,6 +501,7 @@ def _extract_schedule_core(
         meta_map.append((row, col))
 
     ocr_results: List[Dict[str, Any]] = []
+    ocr_start = perf_time.monotonic()
     if tasks:
         max_workers = min(OCR_THREAD_WORKERS, len(tasks)) or 1
         ocr_func = _ocr_diagnostic_task if diagnostics_enabled else _ocr_task
@@ -493,6 +516,7 @@ def _extract_schedule_core(
                         "config": "psm6",
                         "fallback_used": False,
                     })
+    diagnostics["runtime"]["ocr_duration_ms"] = int((perf_time.monotonic() - ocr_start) * 1000)
 
     raw_cells: List[dict] = []
     confidence_values: List[float] = []
@@ -502,8 +526,7 @@ def _extract_schedule_core(
             if diagnostics_enabled:
                 _reject_cell(diagnostics["ocr"]["rejected_cells"], row, col, "empty_ocr", ocr_result)
             continue
-        if diagnostics_enabled:
-            diagnostics["ocr"]["text_cells"] += 1
+        diagnostics["ocr"]["text_cells"] += 1
         confidence = ocr_result.get("confidence")
         if diagnostics_enabled and confidence is not None:
             confidence_values.append(float(confidence))
@@ -542,9 +565,13 @@ def _extract_schedule_core(
         diagnostics["ocr"]["accepted_cells"] = len(raw_cells)
         if confidence_values:
             diagnostics["ocr"]["average_confidence"] = round(float(np.mean(confidence_values)), 2)
+    else:
+        diagnostics["ocr"]["accepted_cells"] = len(raw_cells)
 
     if not raw_cells:
         diagnostics["failure_reason"] = "no_valid_cells"
+        diagnostics["runtime"]["total_duration_ms"] = int((perf_time.monotonic() - start) * 1000)
+        _log_ocr_engine_runtime(diagnostics, 0)
         return {"schedules": [], "diagnostics": diagnostics}
 
     schedule_rows: List[dict] = []
@@ -592,6 +619,8 @@ def _extract_schedule_core(
 
     if not schedule_rows:
         diagnostics["failure_reason"] = "no_mapped_schedule_rows"
+        diagnostics["runtime"]["total_duration_ms"] = int((perf_time.monotonic() - start) * 1000)
+        _log_ocr_engine_runtime(diagnostics, 0)
         return {"schedules": [], "diagnostics": diagnostics}
 
     merged = _merge_adjacent_same_name(schedule_rows)
@@ -599,11 +628,42 @@ def _extract_schedule_core(
     del vertical_mask
     del horizontal_mask
     diagnostics["schedule_count"] = len(merged)
+    diagnostics["runtime"]["total_duration_ms"] = int((perf_time.monotonic() - start) * 1000)
+    _log_ocr_engine_runtime(diagnostics, len(merged))
     return {"schedules": merged, "diagnostics": diagnostics}
+
+
+def _log_ocr_engine_runtime(diagnostics: Dict[str, Any], schedule_count: int) -> None:
+    failure_reason = diagnostics.get("failure_reason")
+    ocr = diagnostics.get("ocr", {})
+    runtime = diagnostics.get("runtime", {})
+    logger.info(
+        runtime_log_message(
+            "timetable_ocr_engine_runtime",
+            component=RuntimeComponent.OCR,
+            operation=RuntimeOperation.OCR,
+            status=RuntimeStatus.SUCCESS if not failure_reason else RuntimeStatus.FALLBACK,
+            duration_ms=runtime.get("total_duration_ms", 0),
+            result_count=schedule_count,
+            fallback=bool(failure_reason) or int(ocr.get("fallback_cells", 0) or 0) > 0,
+            fallback_reason=failure_reason,
+            error_code=None,
+            grid_detection_duration_ms=runtime.get("grid_detection_duration_ms", 0),
+            ocr_duration_ms=runtime.get("ocr_duration_ms", 0),
+            extracted_cell_count=ocr.get("accepted_cells", 0),
+            total_cell_count=ocr.get("total_cells", 0),
+            text_cell_count=ocr.get("text_cells", 0),
+            ocr_fallback_cell_count=ocr.get("fallback_cells", 0),
+        )
+    )
 
 
 def extract_schedule_fixed_scaled(img: np.ndarray) -> List[dict]:
     return _extract_schedule_core(img, diagnostics_enabled=False)["schedules"]
+
+
+def extract_schedule_runtime_report(img: np.ndarray) -> Dict[str, Any]:
+    return _extract_schedule_core(img, diagnostics_enabled=False)
 
 
 def extract_schedule_with_diagnostics(img: np.ndarray, debug_dir: Optional[Path] = None) -> Dict[str, Any]:

--- a/image_analysis/service.py
+++ b/image_analysis/service.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime, timedelta, timezone
@@ -19,9 +20,15 @@ from core.exceptions import (
     ServiceUnavailableError,
     UnauthorizedError,
 )
-from core.logging import get_logger
+from core.logging import (
+    RuntimeComponent,
+    RuntimeOperation,
+    RuntimeStatus,
+    get_logger,
+    runtime_log_message,
+)
 from core.settings import get_settings
-from image_analysis.ocr_engine import extract_schedule_fixed_scaled
+from image_analysis.ocr_engine import extract_schedule_runtime_report
 
 
 logger = get_logger(__name__)
@@ -106,6 +113,7 @@ async def _queue_worker() -> None:
     loop = asyncio.get_running_loop()
     while True:
         job_id, user_id, img, token, appcheck_token = await _job_queue.get()
+        start = time.monotonic()
         job = _job_store.get(job_id)
         if job is None:
             _active_users.discard(user_id)
@@ -114,7 +122,10 @@ async def _queue_worker() -> None:
 
         job["status"] = JobStatus.RUNNING
         try:
-            result = await loop.run_in_executor(_PROCESS_EXECUTOR, extract_schedule_fixed_scaled, img)
+            report = await loop.run_in_executor(_PROCESS_EXECUTOR, extract_schedule_runtime_report, img)
+            result = report.get("schedules", [])
+            diagnostics = report.get("diagnostics", {})
+            _log_timetable_runtime(job_id, start, diagnostics, len(result))
             if result:
                 await _post_to_spring(result, token, appcheck_token)
                 job["status"] = JobStatus.DONE
@@ -125,12 +136,54 @@ async def _queue_worker() -> None:
         except Exception as exc:
             job["status"] = JobStatus.ERROR
             job["error"] = str(exc)
+            logger.error(
+                runtime_log_message(
+                    "timetable_job_runtime",
+                    component=RuntimeComponent.OCR,
+                    operation=RuntimeOperation.REQUEST,
+                    status=RuntimeStatus.FAILED,
+                    duration_ms=int((time.monotonic() - start) * 1000),
+                    result_count=0,
+                    fallback=True,
+                    fallback_reason="worker_exception",
+                    error_code=type(exc).__name__,
+                    job_id=job_id,
+                )
+            )
             logger.exception("timetable_job_failed job_id=%s", job_id, exc_info=exc)
         finally:
             _active_users.discard(user_id)
             _job_store.pop(job_id, None)
             _job_queue.task_done()
             _cleanup_old_jobs()
+
+
+def _log_timetable_runtime(job_id: str, start: float, diagnostics: dict[str, Any], result_count: int) -> None:
+    ocr = diagnostics.get("ocr", {})
+    runtime = diagnostics.get("runtime", {})
+    failure_reason = diagnostics.get("failure_reason")
+    fallback_cell_count = int(ocr.get("fallback_cells", 0) or 0)
+    logger.info(
+        runtime_log_message(
+            "timetable_job_runtime",
+            component=RuntimeComponent.OCR,
+            operation=RuntimeOperation.REQUEST,
+            status=RuntimeStatus.SUCCESS if not failure_reason else RuntimeStatus.FALLBACK,
+            duration_ms=int((time.monotonic() - start) * 1000),
+            result_count=result_count,
+            fallback=bool(failure_reason) or fallback_cell_count > 0,
+            fallback_reason=failure_reason,
+            error_code=None,
+            job_id=job_id,
+            grid_detection_duration_ms=runtime.get("grid_detection_duration_ms", 0),
+            ocr_duration_ms=runtime.get("ocr_duration_ms", 0),
+            engine_total_duration_ms=runtime.get("total_duration_ms", 0),
+            extracted_cell_count=ocr.get("accepted_cells", 0),
+            total_cell_count=ocr.get("total_cells", 0),
+            text_cell_count=ocr.get("text_cells", 0),
+            ocr_fallback_cell_count=fallback_cell_count,
+        )
+    )
 
 
 async def start_queue_workers() -> None:

--- a/image_analysis/service.py
+++ b/image_analysis/service.py
@@ -28,7 +28,7 @@ from core.logging import (
     runtime_log_message,
 )
 from core.settings import get_settings
-from image_analysis.ocr_engine import extract_schedule_runtime_report
+from image_analysis.ocr_engine import configure_ocr_worker_logging, extract_schedule_runtime_report
 
 
 logger = get_logger(__name__)
@@ -40,6 +40,7 @@ _PROCESS_CONTEXT = mp.get_context("spawn")
 _PROCESS_EXECUTOR = ProcessPoolExecutor(
     max_workers=_WORKER_CONCURRENCY,
     mp_context=_PROCESS_CONTEXT,
+    initializer=configure_ocr_worker_logging,
 )
 _WORKER_TASKS: set[asyncio.Task] = set()
 

--- a/text_filtering/service.py
+++ b/text_filtering/service.py
@@ -1,3 +1,4 @@
+import hashlib
 import re
 import time
 from functools import lru_cache
@@ -146,12 +147,13 @@ def _log_ml_filter_runtime(
     english_rule_override_count: int = 0,
     field_count: int = 1,
 ) -> None:
+    runtime_status = RuntimeStatus.FALLBACK if fallback and status == RuntimeStatus.SUCCESS else status
     logger.info(
         runtime_log_message(
             "text_filter_ml_runtime",
             component=RuntimeComponent.TEXT_FILTERING,
             operation=RuntimeOperation.ML_FILTER,
-            status=status,
+            status=runtime_status,
             duration_ms=int((time.monotonic() - start) * 1000),
             result_count=result_count,
             fallback=fallback,
@@ -172,13 +174,18 @@ def _is_model_unavailable() -> bool:
         return True
 
 
+def _sanitized_pending_log_line(sentence: str, label_num: int, sentence_index: int) -> str:
+    text_hash = hashlib.sha256(sentence.encode("utf-8")).hexdigest()[:12]
+    return f"text_hash={text_hash} text_length={len(sentence)} sentence_index={sentence_index}|{label_num}\n"
+
+
 def analyze_field(field_name: str, text: str, should_log: bool = False) -> dict[str, Any]:
     results: list[dict[str, str]] = []
     has_profanity = False
     log_lines: list[str] = []
     english_rule_override_count = 0
 
-    for sentence in split_sentences(text):
+    for sentence_index, sentence in enumerate(split_sentences(text), start=1):
         label_num, label_text = predict(sentence)
         if label_text == "정상" and contains_english_profanity(sentence):
             label_text = "비속어"
@@ -187,7 +194,7 @@ def analyze_field(field_name: str, text: str, should_log: bool = False) -> dict[
 
         results.append({"sentence": sentence, "label": label_text})
         if should_log:
-            log_lines.append(f"{sentence}|{label_num}\n")
+            log_lines.append(_sanitized_pending_log_line(sentence, label_num, sentence_index))
         if label_text == "비속어":
             has_profanity = True
 

--- a/text_filtering/service.py
+++ b/text_filtering/service.py
@@ -1,4 +1,5 @@
 import re
+import time
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -6,7 +7,13 @@ from typing import Any
 import torch
 from transformers import ElectraForSequenceClassification, ElectraTokenizer
 
-from core.logging import get_logger
+from core.logging import (
+    RuntimeComponent,
+    RuntimeOperation,
+    RuntimeStatus,
+    get_logger,
+    runtime_log_message,
+)
 
 
 MODEL_PATH = Path("model/my_electra_finetuned")
@@ -126,16 +133,57 @@ def predict(text: str) -> tuple[int, str]:
     return pred_label, "비속어" if pred_label == 1 else "정상"
 
 
+def _log_ml_filter_runtime(
+    start: float,
+    *,
+    status: RuntimeStatus,
+    sentence_count: int,
+    result_count: int,
+    model_unavailable: bool,
+    fallback: bool,
+    fallback_reason: str | None,
+    error_code: str | None,
+    english_rule_override_count: int = 0,
+    field_count: int = 1,
+) -> None:
+    logger.info(
+        runtime_log_message(
+            "text_filter_ml_runtime",
+            component=RuntimeComponent.TEXT_FILTERING,
+            operation=RuntimeOperation.ML_FILTER,
+            status=status,
+            duration_ms=int((time.monotonic() - start) * 1000),
+            result_count=result_count,
+            fallback=fallback,
+            fallback_reason=fallback_reason,
+            error_code=error_code,
+            sentence_count=sentence_count,
+            field_count=field_count,
+            model_unavailable=model_unavailable,
+            english_rule_override_count=english_rule_override_count,
+        )
+    )
+
+
+def _is_model_unavailable() -> bool:
+    try:
+        return get_text_filter_readiness().get("status") != "ready"
+    except Exception:
+        return True
+
+
 def analyze_field(field_name: str, text: str, should_log: bool = False) -> dict[str, Any]:
     results: list[dict[str, str]] = []
     has_profanity = False
     log_lines: list[str] = []
+    english_rule_override_count = 0
 
     for sentence in split_sentences(text):
         label_num, label_text = predict(sentence)
         if label_text == "정상" and contains_english_profanity(sentence):
             label_text = "비속어"
             label_num = 1
+            english_rule_override_count += 1
 
         results.append({"sentence": sentence, "label": label_text})
         if should_log:
@@ -148,30 +196,94 @@ def analyze_field(field_name: str, text: str, should_log: bool = False) -> dict[
         "has_profanity": has_profanity,
         "results": results,
         "log_lines": log_lines,
+        "english_rule_override_count": english_rule_override_count,
     }
 
 
 def analyze_fields(specs: list[tuple[str, str, bool]]) -> dict[str, dict[str, Any]]:
+    start = time.monotonic()
     analyzed: dict[str, dict[str, Any]] = {}
     pending_logs: list[str] = []
+    sentence_count = 0
+    english_rule_override_count = 0
 
-    for field_name, text, should_log in specs:
-        result = analyze_field(field_name, text, should_log=should_log)
-        pending_logs.extend(result.pop("log_lines"))
-        analyzed[field_name] = result
+    try:
+        for field_name, text, should_log in specs:
+            result = analyze_field(field_name, text, should_log=should_log)
+            sentence_count += len(result.get("results", []))
+            english_rule_override_count += int(result.pop("english_rule_override_count", 0))
+            pending_logs.extend(result.pop("log_lines"))
+            analyzed[field_name] = result
 
-    if pending_logs:
-        with LOG_PATH.open("a", encoding="utf-8") as file:
-            file.writelines(pending_logs)
+        if pending_logs:
+            with LOG_PATH.open("a", encoding="utf-8") as file:
+                file.writelines(pending_logs)
+    except Exception as exc:
+        _log_ml_filter_runtime(
+            start,
+            status=RuntimeStatus.FAILED,
+            sentence_count=sentence_count,
+            result_count=sum(len(result.get("results", [])) for result in analyzed.values()),
+            model_unavailable=_is_model_unavailable(),
+            fallback=True,
+            fallback_reason="analyze_fields_failed",
+            error_code=type(exc).__name__,
+            english_rule_override_count=english_rule_override_count,
+            field_count=len(specs),
+        )
+        raise
+
+    _log_ml_filter_runtime(
+        start,
+        status=RuntimeStatus.SUCCESS,
+        sentence_count=sentence_count,
+        result_count=sum(len(result.get("results", [])) for result in analyzed.values()),
+        model_unavailable=False,
+        fallback=english_rule_override_count > 0,
+        fallback_reason="english_rule_override" if english_rule_override_count > 0 else None,
+        error_code=None,
+        english_rule_override_count=english_rule_override_count,
+        field_count=len(specs),
+    )
 
     return analyzed
 
 
 def analyze_text_labels(text: str) -> list[str]:
+    start = time.monotonic()
     labels: list[str] = []
-    for sentence in split_sentences(text):
-        _, label_text = predict(sentence)
-        if label_text == "정상" and contains_english_profanity(sentence):
-            label_text = "비속어"
-        labels.append(label_text)
+    sentences = split_sentences(text)
+    english_rule_override_count = 0
+    try:
+        for sentence in sentences:
+            _, label_text = predict(sentence)
+            if label_text == "정상" and contains_english_profanity(sentence):
+                label_text = "비속어"
+                english_rule_override_count += 1
+            labels.append(label_text)
+    except Exception as exc:
+        _log_ml_filter_runtime(
+            start,
+            status=RuntimeStatus.FAILED,
+            sentence_count=len(sentences),
+            result_count=len(labels),
+            model_unavailable=_is_model_unavailable(),
+            fallback=True,
+            fallback_reason="analyze_text_labels_failed",
+            error_code=type(exc).__name__,
+            english_rule_override_count=english_rule_override_count,
+        )
+        raise
+
+    _log_ml_filter_runtime(
+        start,
+        status=RuntimeStatus.SUCCESS,
+        sentence_count=len(sentences),
+        result_count=len(labels),
+        model_unavailable=False,
+        fallback=english_rule_override_count > 0,
+        fallback_reason="english_rule_override" if english_rule_override_count > 0 else None,
+        error_code=None,
+        english_rule_override_count=english_rule_override_count,
+    )
     return labels

--- a/text_filtering/text_filtering_rule.py
+++ b/text_filtering/text_filtering_rule.py
@@ -1,16 +1,62 @@
+import time
+
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from core.auth import verify_jwt_token
 from core.exceptions import BadRequestError
+from core.logging import (
+    RuntimeComponent,
+    RuntimeOperation,
+    RuntimeStatus,
+    get_logger,
+    runtime_log_message,
+)
 from text_filtering.service import analyze_fields
 
 router = APIRouter()
+logger = get_logger(__name__)
 
 
 class TextRequest(BaseModel):
     text: str
+
+
+def _log_rule_filter_runtime(
+    endpoint: str,
+    start: float,
+    *,
+    status: RuntimeStatus,
+    field_count: int,
+    sentence_count: int,
+    result_count: int,
+    has_profanity: bool,
+    fallback: bool = False,
+    fallback_reason: str | None = None,
+    error_code: str | None = None,
+) -> None:
+    logger.info(
+        runtime_log_message(
+            "text_filter_rule_runtime",
+            component=RuntimeComponent.TEXT_FILTERING,
+            operation=RuntimeOperation.RULE_FILTER,
+            status=status,
+            duration_ms=int((time.monotonic() - start) * 1000),
+            result_count=result_count,
+            fallback=fallback,
+            fallback_reason=fallback_reason,
+            error_code=error_code,
+            endpoint=endpoint,
+            field_count=field_count,
+            sentence_count=sentence_count,
+            has_profanity=has_profanity,
+        )
+    )
+
+
+def _count_result_sentences(*results: dict) -> int:
+    return sum(len(result.get("results", [])) for result in results)
 
 
 @router.post("/text_filter_rule")
@@ -28,11 +74,27 @@ async def rule_filter_api(
             code="invalid_text_filter_rule_format",
         ) from exc
 
-    analyzed = analyze_fields([
-        ("제목", title, True),
-        ("태그", tags, False),
-        ("본문", content, True),
-    ])
+    start = time.monotonic()
+    try:
+        analyzed = analyze_fields([
+            ("제목", title, True),
+            ("태그", tags, False),
+            ("본문", content, True),
+        ])
+    except Exception as exc:
+        _log_rule_filter_runtime(
+            "/text_filter_rule",
+            start,
+            status=RuntimeStatus.FAILED,
+            field_count=3,
+            sentence_count=0,
+            result_count=0,
+            has_profanity=False,
+            fallback=True,
+            fallback_reason="rule_filter_failed",
+            error_code=type(exc).__name__,
+        )
+        raise
     title_result = analyzed["제목"]
     tags_result = analyzed["태그"]
     content_result = analyzed["본문"]
@@ -44,7 +106,19 @@ async def rule_filter_api(
         "본문": content_result
     }
 
-    if title_result["has_profanity"] or tags_result["has_profanity"] or content_result["has_profanity"]:
+    has_profanity = title_result["has_profanity"] or tags_result["has_profanity"] or content_result["has_profanity"]
+    result_count = _count_result_sentences(title_result, tags_result, content_result)
+    _log_rule_filter_runtime(
+        "/text_filter_rule",
+        start,
+        status=RuntimeStatus.SUCCESS,
+        field_count=3,
+        sentence_count=result_count,
+        result_count=result_count,
+        has_profanity=has_profanity,
+    )
+
+    if has_profanity:
         return JSONResponse(content=response, status_code=400)
     return JSONResponse(content=response, status_code=200)
 
@@ -53,14 +127,41 @@ async def rule_filter_api(
 async def text_filter_content_api(
     payload: TextRequest):
     text = payload.text.strip()
-    analyzed = analyze_fields([
-        ("content", text, True),
-    ])
+    start = time.monotonic()
+    try:
+        analyzed = analyze_fields([
+            ("content", text, True),
+        ])
+    except Exception as exc:
+        _log_rule_filter_runtime(
+            "/text_filter_content",
+            start,
+            status=RuntimeStatus.FAILED,
+            field_count=1,
+            sentence_count=0,
+            result_count=0,
+            has_profanity=False,
+            fallback=True,
+            fallback_reason="content_filter_failed",
+            error_code=type(exc).__name__,
+        )
+        raise
     content_result = analyzed["content"]
 
     response = {
         "content": content_result
     }
+
+    result_count = _count_result_sentences(content_result)
+    _log_rule_filter_runtime(
+        "/text_filter_content",
+        start,
+        status=RuntimeStatus.SUCCESS,
+        field_count=1,
+        sentence_count=result_count,
+        result_count=result_count,
+        has_profanity=content_result["has_profanity"],
+    )
 
     return JSONResponse(
         status_code=400 if content_result["has_profanity"] else 200,

--- a/text_filtering/text_filtering_rule.py
+++ b/text_filtering/text_filtering_rule.py
@@ -36,12 +36,13 @@ def _log_rule_filter_runtime(
     fallback_reason: str | None = None,
     error_code: str | None = None,
 ) -> None:
+    runtime_status = RuntimeStatus.FALLBACK if fallback and status == RuntimeStatus.SUCCESS else status
     logger.info(
         runtime_log_message(
             "text_filter_rule_runtime",
             component=RuntimeComponent.TEXT_FILTERING,
             operation=RuntimeOperation.RULE_FILTER,
-            status=status,
+            status=runtime_status,
             duration_ms=int((time.monotonic() - start) * 1000),
             result_count=result_count,
             fallback=fallback,


### PR DESCRIPTION
## 관련 이슈
Closes #136 

## 🎯 배경
- 운영 환경에서 챗봇, OCR, 텍스트 필터링의 latency/result/fallback 신호를 request id 흐름과 함께 확인할 필요가 있습니다.
- metric endpoint를 바로 추가하기보다, 우선 structured log 필드 표준화를 통해 런타임 품질 신호를 안전하게 남깁니다.

## 🔍 주요 내용
- 공통 runtime log field/helper 추가
- 챗봇 retrieval, LLM, request summary 로그 추가
- OCR engine 및 queue worker duration/result/fallback 로그 추가
- text filtering ML/rule 분석 latency 및 fallback 로그 추가
- 원문 텍스트, 토큰, payload 대신 hash/count/status 중심으로 기록

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 변경 요약(1~3줄)
런타임 품질 로그 포맷을 공통으로 표준화해 챗봇, OCR, 텍스트 필터링 흐름에서 지연/폴백/결과 수 같은 운영 신호를 일관되게 남기도록 했어요. 요청 ID 흐름은 그대로 두고, 민감 정보는 로그에 남기지 않도록 필드도 정리했습니다.

## 주요 변경점(불릿 3~7개)
- `core/logging/runtime.py` 추가: `RuntimeComponent/RuntimeOperation/RuntimeStatus`와 `runtime_log_message()`로 `event key=value ...` 형식 공통화
- 챗봇(OSS) 로깅 강화: retrieval/LLM/총 지연, top-k 결과 수, direct-answer 라우트 여부, BM25 폴백 티어/폴백 이유, 실패 에러 코드까지 구조화
- 검색 인덱스 조회(`query_index.py`)에 성공/실패 duration·result_count·fallback 정보와 `retrieval_failed` 같은 에러 코드 기록
- OCR 로깅 확장: grid/OCR/total duration, 추출 셀 수, 엔진 결과 개수 및 fallback reason을 워커/엔진 양쪽에서 구조화
- 텍스트 필터링 로깅: rule/ML 처리 latency, model unavailable·fallback 상태/사유, 결과/문장 수, 영어 룰 오버라이드 횟수 기록 + pending 로그는 해시/길이 기반으로 위생 처리
- 룰 엔드포인트(`/text_filter_rule`, `/text_filter_content`)에서 처리 시간과 status(Failed/Success) 및 fallback/error_code를 이벤트로 남김

## 주의/리스크(있으면 1~3개)
- 이벤트/필드가 늘어나면서 로그 볼륨이 증가할 수 있어요.
- fallback 판정 로직이 여러 단계에서 반영되므로, 대시보드에서 의미(“fallback=True”의 원인)가 동일하게 해석되는지 확인이 필요해요.

## 다음 액션(있으면 1~3개)
- 주요 시나리오(정상/폴백/실패)별로 이벤트 이름과 핵심 필드(`duration_ms`, `result_count`, `fallback_reason`, `bm25_fallback_tier`)가 기대대로 찍히는지 샘플링 점검
- 운영 대시보드/쿼리를 `query_hash`, `duration_ms`, `result_count` 중심으로 구성해 빠르게 상관 분석 가능하도록 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->