### PR TITLE
feat: optimize timetable ocr cell filtering

### DIFF
--- a/image_analysis/ocr_engine.py
+++ b/image_analysis/ocr_engine.py
@@ -47,6 +47,7 @@ TRIM_OUTER, TRIM_X_GAP, TRIM_Y_GAP = True, 20, 15
 OCR_THREAD_WORKERS = 8
 LOW_OCR_CONFIDENCE = 55.0
 MAX_REJECTED_CELLS_IN_DIAGNOSTICS = 120
+EMPTY_CELL_FOREGROUND_DENSITY_THRESHOLD = 0.005
 
 
 def configure_ocr_worker_logging() -> None:
@@ -259,6 +260,32 @@ def assess_image_quality(img_bgr: np.ndarray) -> Dict[str, Any]:
     }
 
 
+def _foreground_density(roi_gray: np.ndarray) -> float:
+    height, width = roi_gray.shape[:2]
+    if height <= 0 or width <= 0:
+        return 0.0
+
+    margin_y = max(1, int(height * 0.06))
+    margin_x = max(1, int(width * 0.06))
+    if height > margin_y * 2 and width > margin_x * 2:
+        roi_gray = roi_gray[margin_y:height - margin_y, margin_x:width - margin_x]
+
+    blurred = cv2.GaussianBlur(roi_gray, (3, 3), 0)
+    _, dark_mask = cv2.threshold(blurred, 205, 255, cv2.THRESH_BINARY_INV)
+    if min(dark_mask.shape[:2]) >= 2:
+        kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (2, 2))
+        dark_mask = cv2.morphologyEx(dark_mask, cv2.MORPH_OPEN, kernel, iterations=1)
+
+    area = dark_mask.shape[0] * dark_mask.shape[1]
+    if area <= 0:
+        return 0.0
+    return round(float(cv2.countNonZero(dark_mask)) / float(area), 6)
+
+
+def _is_empty_cell_candidate(roi_gray: np.ndarray) -> bool:
+    return _foreground_density(roi_gray) <= EMPTY_CELL_FOREGROUND_DENSITY_THRESHOLD
+
+
 def _save_grid_debug_image(base_gray: np.ndarray, x_lines: List[int], y_lines: List[int], output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     overlay = cv2.cvtColor(base_gray, cv2.COLOR_GRAY2BGR)
@@ -441,6 +468,9 @@ def _extract_schedule_core(
         "grid": {},
         "ocr": {
             "total_cells": 0,
+            "ocr_task_cells": 0,
+            "skipped_empty_cells": 0,
+            "empty_cell_skip_threshold": EMPTY_CELL_FOREGROUND_DENSITY_THRESHOLD,
             "text_cells": 0,
             "accepted_cells": 0,
             "rejected_cells": [],
@@ -504,6 +534,11 @@ def _extract_schedule_core(
         if row == 0:
             continue
         diagnostics["ocr"]["total_cells"] += 1
+        if _is_empty_cell_candidate(roi_gray):
+            diagnostics["ocr"]["skipped_empty_cells"] += 1
+            if diagnostics_enabled:
+                _reject_cell(diagnostics["ocr"]["rejected_cells"], row, col, "skipped_empty_cell")
+            continue
         ok, buf = cv2.imencode(".png", roi_gray)
         if not ok:
             if diagnostics_enabled:
@@ -511,6 +546,7 @@ def _extract_schedule_core(
             continue
         tasks.append(buf.tobytes())
         meta_map.append((row, col))
+        diagnostics["ocr"]["ocr_task_cells"] += 1
 
     ocr_results: List[Dict[str, Any]] = []
     ocr_start = perf_time.monotonic()
@@ -665,7 +701,9 @@ def _log_ocr_engine_runtime(diagnostics: Dict[str, Any], schedule_count: int) ->
             ocr_duration_ms=runtime.get("ocr_duration_ms", 0),
             extracted_cell_count=ocr.get("accepted_cells", 0),
             total_cell_count=ocr.get("total_cells", 0),
+            ocr_task_cell_count=ocr.get("ocr_task_cells", 0),
             text_cell_count=ocr.get("text_cells", 0),
+            skipped_empty_cell_count=ocr.get("skipped_empty_cells", 0),
             ocr_fallback_cell_count=ocr.get("fallback_cells", 0),
         )
     )

--- a/image_analysis/ocr_engine.py
+++ b/image_analysis/ocr_engine.py
@@ -50,6 +50,7 @@ MAX_REJECTED_CELLS_IN_DIAGNOSTICS = 120
 EMPTY_CELL_FOREGROUND_DENSITY_THRESHOLD = 0.005
 MAX_RUNTIME_FALLBACK_CELLS = 5
 EMPTY_FALLBACK_FOREGROUND_DENSITY_THRESHOLD = 0.05
+MIN_TEXT_COMPONENTS_IN_CELL = 1
 
 
 def configure_ocr_worker_logging() -> None:
@@ -319,10 +320,10 @@ def assess_image_quality(img_bgr: np.ndarray) -> Dict[str, Any]:
     }
 
 
-def _foreground_density(roi_gray: np.ndarray) -> float:
+def _cell_foreground_mask(roi_gray: np.ndarray) -> np.ndarray:
     height, width = roi_gray.shape[:2]
     if height <= 0 or width <= 0:
-        return 0.0
+        return np.zeros((0, 0), dtype=np.uint8)
 
     margin_y = max(1, int(height * 0.06))
     margin_x = max(1, int(width * 0.06))
@@ -334,15 +335,51 @@ def _foreground_density(roi_gray: np.ndarray) -> float:
     if min(dark_mask.shape[:2]) >= 2:
         kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (2, 2))
         dark_mask = cv2.morphologyEx(dark_mask, cv2.MORPH_OPEN, kernel, iterations=1)
+    return dark_mask
 
+
+def _foreground_density(roi_gray: np.ndarray) -> float:
+    dark_mask = _cell_foreground_mask(roi_gray)
     area = dark_mask.shape[0] * dark_mask.shape[1]
     if area <= 0:
         return 0.0
     return round(float(cv2.countNonZero(dark_mask)) / float(area), 6)
 
 
+def _text_component_count(roi_gray: np.ndarray) -> int:
+    dark_mask = _cell_foreground_mask(roi_gray)
+    if dark_mask.size == 0:
+        return 0
+
+    count, labels, stats, _ = cv2.connectedComponentsWithStats(dark_mask, connectivity=8)
+    height, width = dark_mask.shape[:2]
+    area = height * width
+    text_components = 0
+    for label in range(1, count):
+        x, y, component_width, component_height, component_area = stats[label]
+        if component_area < 4:
+            continue
+        if component_area > area * 0.18:
+            continue
+        if component_width > width * 0.75 or component_height > height * 0.75:
+            continue
+        if component_width < 2 or component_height < 2:
+            continue
+        aspect_ratio = component_width / max(component_height, 1)
+        if aspect_ratio > 12.0 or aspect_ratio < 0.08:
+            continue
+        text_components += 1
+    return text_components
+
+
+def _has_text_presence(roi_gray: np.ndarray) -> bool:
+    if _foreground_density(roi_gray) <= EMPTY_CELL_FOREGROUND_DENSITY_THRESHOLD:
+        return False
+    return _text_component_count(roi_gray) >= MIN_TEXT_COMPONENTS_IN_CELL
+
+
 def _is_empty_cell_candidate(roi_gray: np.ndarray) -> bool:
-    return _foreground_density(roi_gray) <= EMPTY_CELL_FOREGROUND_DENSITY_THRESHOLD
+    return not _has_text_presence(roi_gray)
 
 
 def _save_grid_debug_image(base_gray: np.ndarray, x_lines: List[int], y_lines: List[int], output_path: Path) -> None:
@@ -530,6 +567,7 @@ def _extract_schedule_core(
             "ocr_task_cells": 0,
             "skipped_empty_cells": 0,
             "empty_cell_skip_threshold": EMPTY_CELL_FOREGROUND_DENSITY_THRESHOLD,
+            "min_text_components_in_cell": MIN_TEXT_COMPONENTS_IN_CELL,
             "runtime_fallback_limit": MAX_RUNTIME_FALLBACK_CELLS,
             "runtime_fallback_candidates": 0,
             "runtime_fallback_attempted_cells": 0,

--- a/image_analysis/ocr_engine.py
+++ b/image_analysis/ocr_engine.py
@@ -229,6 +229,58 @@ def _should_consider_runtime_fallback(lines: List[str], foreground_density: floa
     }
 
 
+def _run_runtime_ocr_with_fallback(
+    tasks: List[bytes],
+    foreground_density_map: List[float],
+) -> tuple[List[Dict[str, Any]], Dict[str, int]]:
+    ocr_results: List[Dict[str, Any]] = []
+    metrics = {
+        "runtime_fallback_candidates": 0,
+        "runtime_fallback_attempted_cells": 0,
+    }
+    if not tasks:
+        return ocr_results, metrics
+
+    max_workers = min(OCR_THREAD_WORKERS, len(tasks)) or 1
+    with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ocr_cell") as executor:
+        for result in executor.map(_ocr_task, tasks):
+            ocr_results.append({
+                "lines": result,
+                "confidence": None,
+                "config": "psm6",
+                "fallback_used": False,
+            })
+
+    fallback_candidates: List[tuple[float, int, bytes]] = []
+    for index, (ocr_result, roi_bytes) in enumerate(zip(ocr_results, tasks)):
+        lines = ocr_result.get("lines") or []
+        if _reject_reason_for_lines(lines) is None:
+            continue
+        foreground_density = foreground_density_map[index]
+        if not _should_consider_runtime_fallback(lines, foreground_density):
+            continue
+        fallback_candidates.append((
+            _runtime_fallback_score(lines, foreground_density),
+            index,
+            roi_bytes,
+        ))
+
+    metrics["runtime_fallback_candidates"] = len(fallback_candidates)
+    fallback_candidates.sort(key=lambda item: item[0], reverse=True)
+    fallback_candidates = fallback_candidates[:MAX_RUNTIME_FALLBACK_CELLS]
+    metrics["runtime_fallback_attempted_cells"] = len(fallback_candidates)
+    if fallback_candidates:
+        max_workers = min(OCR_THREAD_WORKERS, len(fallback_candidates)) or 1
+        with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ocr_fallback") as executor:
+            fallback_results = executor.map(_ocr_fallback_task, [item[2] for item in fallback_candidates])
+            for (_, index, _), fallback_result in zip(fallback_candidates, fallback_results):
+                fallback_lines = fallback_result.get("lines") or []
+                if _reject_reason_for_lines(fallback_lines) is None:
+                    ocr_results[index] = fallback_result
+
+    return ocr_results, metrics
+
+
 def _split_slot(slot: str) -> Optional[tuple[str, str]]:
     if slot is None:
         return None
@@ -653,47 +705,14 @@ def _extract_schedule_core(
     ocr_results: List[Dict[str, Any]] = []
     ocr_start = perf_time.monotonic()
     if tasks:
-        max_workers = min(OCR_THREAD_WORKERS, len(tasks)) or 1
-        ocr_func = _ocr_diagnostic_task if diagnostics_enabled else _ocr_task
-        with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ocr_cell") as executor:
-            for result in executor.map(ocr_func, tasks):
-                if diagnostics_enabled:
-                    ocr_results.append(result)
-                else:
-                    ocr_results.append({
-                        "lines": result,
-                        "confidence": None,
-                        "config": "psm6",
-                        "fallback_used": False,
-                    })
-
-    if not diagnostics_enabled and ocr_results:
-        fallback_candidates: List[tuple[float, int, bytes]] = []
-        for index, (ocr_result, roi_bytes) in enumerate(zip(ocr_results, tasks)):
-            lines = ocr_result.get("lines") or []
-            if _reject_reason_for_lines(lines) is None:
-                continue
-            foreground_density = foreground_density_map[index]
-            if not _should_consider_runtime_fallback(lines, foreground_density):
-                continue
-            fallback_candidates.append((
-                _runtime_fallback_score(lines, foreground_density),
-                index,
-                roi_bytes,
-            ))
-
-        diagnostics["ocr"]["runtime_fallback_candidates"] = len(fallback_candidates)
-        fallback_candidates.sort(key=lambda item: item[0], reverse=True)
-        fallback_candidates = fallback_candidates[:MAX_RUNTIME_FALLBACK_CELLS]
-        diagnostics["ocr"]["runtime_fallback_attempted_cells"] = len(fallback_candidates)
-        if fallback_candidates:
-            max_workers = min(OCR_THREAD_WORKERS, len(fallback_candidates)) or 1
-            with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ocr_fallback") as executor:
-                fallback_results = executor.map(_ocr_fallback_task, [item[2] for item in fallback_candidates])
-                for (_, index, _), fallback_result in zip(fallback_candidates, fallback_results):
-                    fallback_lines = fallback_result.get("lines") or []
-                    if _reject_reason_for_lines(fallback_lines) is None:
-                        ocr_results[index] = fallback_result
+        if diagnostics_enabled:
+            max_workers = min(OCR_THREAD_WORKERS, len(tasks)) or 1
+            with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ocr_cell") as executor:
+                ocr_results.extend(executor.map(_ocr_diagnostic_task, tasks))
+        else:
+            ocr_results, runtime_ocr_metrics = _run_runtime_ocr_with_fallback(tasks, foreground_density_map)
+            diagnostics["ocr"]["runtime_fallback_candidates"] = runtime_ocr_metrics["runtime_fallback_candidates"]
+            diagnostics["ocr"]["runtime_fallback_attempted_cells"] = runtime_ocr_metrics["runtime_fallback_attempted_cells"]
 
     diagnostics["runtime"]["ocr_duration_ms"] = int((perf_time.monotonic() - ocr_start) * 1000)
 
@@ -718,15 +737,11 @@ def _extract_schedule_core(
         professor = lines[1] if len(lines) > 1 else ""
         room = lines[2] if len(lines) > 2 else ""
 
-        if len(course) > 15 or len(professor) > 8 or len(room) > 10:
-            if diagnostics_enabled:
-                _reject_cell(diagnostics["ocr"]["rejected_cells"], row, col, "field_too_long", ocr_result)
-            continue
-
+        reject_reason = _reject_reason_for_lines(lines)
         room = room.replace("=", "-")
-        if not (_is_valid_course(course) and _is_valid_professor(professor)):
+        if reject_reason is not None:
             if diagnostics_enabled:
-                _reject_cell(diagnostics["ocr"]["rejected_cells"], row, col, "invalid_course_or_professor", ocr_result)
+                _reject_cell(diagnostics["ocr"]["rejected_cells"], row, col, reject_reason, ocr_result)
             continue
 
         raw_cells.append({

--- a/image_analysis/ocr_engine.py
+++ b/image_analysis/ocr_engine.py
@@ -48,6 +48,8 @@ OCR_THREAD_WORKERS = 8
 LOW_OCR_CONFIDENCE = 55.0
 MAX_REJECTED_CELLS_IN_DIAGNOSTICS = 120
 EMPTY_CELL_FOREGROUND_DENSITY_THRESHOLD = 0.005
+MAX_RUNTIME_FALLBACK_CELLS = 5
+EMPTY_FALLBACK_FOREGROUND_DENSITY_THRESHOLD = 0.05
 
 
 def configure_ocr_worker_logging() -> None:
@@ -115,6 +117,18 @@ def _ocr_task(roi_bytes: bytes) -> List[str]:
     return _clean_ocr_lines(text)
 
 
+def _ocr_fallback_task(roi_bytes: bytes) -> Dict[str, Any]:
+    nparr = np.frombuffer(roi_bytes, np.uint8)
+    roi_gray = cv2.imdecode(nparr, cv2.IMREAD_GRAYSCALE)
+    text = pytesseract.image_to_string(Image.fromarray(roi_gray), config=fallback_tesseract_config).strip()
+    return {
+        "lines": _clean_ocr_lines(text),
+        "confidence": None,
+        "config": "psm11",
+        "fallback_used": True,
+    }
+
+
 def _is_acceptable_ocr_candidate(candidate: Dict[str, Any]) -> bool:
     lines = candidate.get("lines") or []
     if not lines:
@@ -167,6 +181,51 @@ def _is_valid_course(value: str) -> bool:
 def _is_valid_professor(value: str) -> bool:
     value = value.strip()
     return len(value) >= 2 and _hangul.search(value) is not None and _long_repeat.search(value) is None
+
+
+def _reject_reason_for_lines(lines: List[str]) -> Optional[str]:
+    if not lines:
+        return "empty_ocr"
+
+    course = lines[0]
+    professor = lines[1] if len(lines) > 1 else ""
+    room = lines[2] if len(lines) > 2 else ""
+    if len(course) > 15 or len(professor) > 8 or len(room) > 10:
+        return "field_too_long"
+    if not (_is_valid_course(course) and _is_valid_professor(professor)):
+        return "invalid_course_or_professor"
+    return None
+
+
+def _runtime_fallback_score(lines: List[str], foreground_density: float) -> float:
+    if not lines:
+        return 20.0 + foreground_density
+
+    score = 40.0 + min(len(lines), 3) * 5.0 + foreground_density
+    course_valid = _is_valid_course(lines[0])
+    professor_valid = len(lines) >= 2 and _is_valid_professor(lines[1])
+    if course_valid != professor_valid:
+        score += 50.0
+    elif course_valid or professor_valid:
+        score += 25.0
+    elif any(_hangul.search(line) for line in lines):
+        score += 10.0
+    return score
+
+
+def _should_consider_runtime_fallback(lines: List[str], foreground_density: float) -> bool:
+    if not lines:
+        return foreground_density >= EMPTY_FALLBACK_FOREGROUND_DENSITY_THRESHOLD
+
+    if not any(_hangul.search(line) for line in lines):
+        return False
+
+    course_valid = _is_valid_course(lines[0])
+    professor_valid = len(lines) >= 2 and _is_valid_professor(lines[1])
+    return course_valid != professor_valid or _reject_reason_for_lines(lines) in {
+        "field_too_long",
+        "invalid_course_or_professor",
+    }
 
 
 def _split_slot(slot: str) -> Optional[tuple[str, str]]:
@@ -471,6 +530,9 @@ def _extract_schedule_core(
             "ocr_task_cells": 0,
             "skipped_empty_cells": 0,
             "empty_cell_skip_threshold": EMPTY_CELL_FOREGROUND_DENSITY_THRESHOLD,
+            "runtime_fallback_limit": MAX_RUNTIME_FALLBACK_CELLS,
+            "runtime_fallback_candidates": 0,
+            "runtime_fallback_attempted_cells": 0,
             "text_cells": 0,
             "accepted_cells": 0,
             "rejected_cells": [],
@@ -530,6 +592,7 @@ def _extract_schedule_core(
 
     tasks: List[bytes] = []
     meta_map: List[tuple[int, int]] = []
+    foreground_density_map: List[float] = []
     for row, col, roi_gray in _iterate_cells_autogrid(base_gray, x_lines, y_lines):
         if row == 0:
             continue
@@ -546,6 +609,7 @@ def _extract_schedule_core(
             continue
         tasks.append(buf.tobytes())
         meta_map.append((row, col))
+        foreground_density_map.append(_foreground_density(roi_gray))
         diagnostics["ocr"]["ocr_task_cells"] += 1
 
     ocr_results: List[Dict[str, Any]] = []
@@ -564,6 +628,35 @@ def _extract_schedule_core(
                         "config": "psm6",
                         "fallback_used": False,
                     })
+
+    if not diagnostics_enabled and ocr_results:
+        fallback_candidates: List[tuple[float, int, bytes]] = []
+        for index, (ocr_result, roi_bytes) in enumerate(zip(ocr_results, tasks)):
+            lines = ocr_result.get("lines") or []
+            if _reject_reason_for_lines(lines) is None:
+                continue
+            foreground_density = foreground_density_map[index]
+            if not _should_consider_runtime_fallback(lines, foreground_density):
+                continue
+            fallback_candidates.append((
+                _runtime_fallback_score(lines, foreground_density),
+                index,
+                roi_bytes,
+            ))
+
+        diagnostics["ocr"]["runtime_fallback_candidates"] = len(fallback_candidates)
+        fallback_candidates.sort(key=lambda item: item[0], reverse=True)
+        fallback_candidates = fallback_candidates[:MAX_RUNTIME_FALLBACK_CELLS]
+        diagnostics["ocr"]["runtime_fallback_attempted_cells"] = len(fallback_candidates)
+        if fallback_candidates:
+            max_workers = min(OCR_THREAD_WORKERS, len(fallback_candidates)) or 1
+            with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ocr_fallback") as executor:
+                fallback_results = executor.map(_ocr_fallback_task, [item[2] for item in fallback_candidates])
+                for (_, index, _), fallback_result in zip(fallback_candidates, fallback_results):
+                    fallback_lines = fallback_result.get("lines") or []
+                    if _reject_reason_for_lines(fallback_lines) is None:
+                        ocr_results[index] = fallback_result
+
     diagnostics["runtime"]["ocr_duration_ms"] = int((perf_time.monotonic() - ocr_start) * 1000)
 
     raw_cells: List[dict] = []
@@ -580,7 +673,7 @@ def _extract_schedule_core(
             confidence_values.append(float(confidence))
             if confidence < LOW_OCR_CONFIDENCE:
                 diagnostics["ocr"]["low_confidence_cells"] += 1
-        if diagnostics_enabled and ocr_result.get("fallback_used"):
+        if ocr_result.get("fallback_used"):
             diagnostics["ocr"]["fallback_cells"] += 1
 
         course = lines[0]
@@ -686,15 +779,16 @@ def _log_ocr_engine_runtime(diagnostics: Dict[str, Any], schedule_count: int) ->
     failure_reason = diagnostics.get("failure_reason")
     ocr = diagnostics.get("ocr", {})
     runtime = diagnostics.get("runtime", {})
+    fallback_cell_count = int(ocr.get("fallback_cells", 0) or 0)
     logger.info(
         runtime_log_message(
             "timetable_ocr_engine_runtime",
             component=RuntimeComponent.OCR,
             operation=RuntimeOperation.OCR,
-            status=RuntimeStatus.SUCCESS if not failure_reason else RuntimeStatus.FALLBACK,
+            status=RuntimeStatus.SUCCESS if not failure_reason and fallback_cell_count == 0 else RuntimeStatus.FALLBACK,
             duration_ms=runtime.get("total_duration_ms", 0),
             result_count=schedule_count,
-            fallback=bool(failure_reason) or int(ocr.get("fallback_cells", 0) or 0) > 0,
+            fallback=bool(failure_reason) or fallback_cell_count > 0,
             fallback_reason=failure_reason,
             error_code=None,
             grid_detection_duration_ms=runtime.get("grid_detection_duration_ms", 0),
@@ -704,7 +798,9 @@ def _log_ocr_engine_runtime(diagnostics: Dict[str, Any], schedule_count: int) ->
             ocr_task_cell_count=ocr.get("ocr_task_cells", 0),
             text_cell_count=ocr.get("text_cells", 0),
             skipped_empty_cell_count=ocr.get("skipped_empty_cells", 0),
-            ocr_fallback_cell_count=ocr.get("fallback_cells", 0),
+            ocr_fallback_cell_count=fallback_cell_count,
+            runtime_fallback_candidate_count=ocr.get("runtime_fallback_candidates", 0),
+            runtime_fallback_attempted_cell_count=ocr.get("runtime_fallback_attempted_cells", 0),
         )
     )
 

--- a/image_analysis/service.py
+++ b/image_analysis/service.py
@@ -181,7 +181,9 @@ def _log_timetable_runtime(job_id: str, start: float, diagnostics: dict[str, Any
             engine_total_duration_ms=runtime.get("total_duration_ms", 0),
             extracted_cell_count=ocr.get("accepted_cells", 0),
             total_cell_count=ocr.get("total_cells", 0),
+            ocr_task_cell_count=ocr.get("ocr_task_cells", 0),
             text_cell_count=ocr.get("text_cells", 0),
+            skipped_empty_cell_count=ocr.get("skipped_empty_cells", 0),
             ocr_fallback_cell_count=fallback_cell_count,
         )
     )

--- a/image_analysis/service.py
+++ b/image_analysis/service.py
@@ -164,15 +164,16 @@ def _log_timetable_runtime(job_id: str, start: float, diagnostics: dict[str, Any
     runtime = diagnostics.get("runtime", {})
     failure_reason = diagnostics.get("failure_reason")
     fallback_cell_count = int(ocr.get("fallback_cells", 0) or 0)
+    fallback_used = bool(failure_reason) or fallback_cell_count > 0
     logger.info(
         runtime_log_message(
             "timetable_job_runtime",
             component=RuntimeComponent.OCR,
             operation=RuntimeOperation.REQUEST,
-            status=RuntimeStatus.SUCCESS if not failure_reason else RuntimeStatus.FALLBACK,
+            status=RuntimeStatus.SUCCESS if not fallback_used else RuntimeStatus.FALLBACK,
             duration_ms=int((time.monotonic() - start) * 1000),
             result_count=result_count,
-            fallback=bool(failure_reason) or fallback_cell_count > 0,
+            fallback=fallback_used,
             fallback_reason=failure_reason,
             error_code=None,
             job_id=job_id,

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -13,6 +13,7 @@ python tests/regression/chatbot/evaluate_rag_retrieval.py --validate-only
 python tests/regression/chatbot/evaluate_rag_retrieval.py
 python tests/regression/chatbot/check_chatbot_tool_routing.py
 python tests/regression/timetable/check_timetable_ocr_diagnostics.py
+python tests/regression/timetable/measure_timetable_ocr_baseline.py
 python tests/regression/text_filtering/check_text_filter_quality_report.py
 ```
 
@@ -52,6 +53,32 @@ python tests/regression/text_filtering/check_text_filter_quality_report.py
 - `fallback_cell_count`: fallback OCR 경로가 선택된 셀 수
 
 `cv2`, `pytesseract`, Tesseract 런타임이 없는 환경에서는 실패 대신 `status: "skipped"` 리포트를 기본 경로에 기록합니다.
+
+### Timetable OCR Performance Baseline
+
+`tests/regression/timetable/measure_timetable_ocr_baseline.py`는 `tests/regression/timetable/timetable_ocr_performance_cases.json`의 실제 시간표 이미지 샘플을 읽어 현재 OCR 런타임 기준선을 기록합니다. 운영 경로와 가깝게 측정하기 위해 `extract_schedule_runtime_report()`를 호출하며, OCR 인식 로직은 변경하지 않습니다.
+
+- `average_total_duration_ms`, `max_total_duration_ms`, `p95_total_duration_ms`: 전체 처리 시간 기준선
+- `average_grid_detection_duration_ms`, `max_grid_detection_duration_ms`: 격자 검출 시간 기준선
+- `average_ocr_duration_ms`, `max_ocr_duration_ms`: Tesseract OCR 시간 기준선
+- `total_extracted_schedule_count`: 추출된 시간표 항목 수 합계
+- `failure_count`, `failure_reasons`: 실패 사유 관측치
+
+기본 리포트는 `tests/reports/timetable/timetable_ocr_performance_baseline.json`에 저장됩니다. `data/`가 로컬/운영 샘플 영역이라 이미지 파일이 없는 케이스는 전체 실패 대신 개별 `skipped` 케이스로 기록합니다. OCI에서는 부하를 낮추기 위해 기본 `--repeat 1`을 권장하고, 안정적인 비교가 필요할 때만 반복 횟수를 늘립니다.
+
+OCI 운영 서버와 비교할 때는 먼저 서버에서 기본 운영 프로필을 그대로 측정합니다.
+
+```bash
+python tests/regression/timetable/measure_timetable_ocr_baseline.py --profile production --repeat 1
+```
+
+로컬에서 OCI 제약에 가까운 보수적 기준선을 보고 싶을 때는 셀 OCR worker 수를 줄인 프로필을 사용합니다. 이 프로필은 현재 프로세스 안에서만 `image_analysis.ocr_engine.OCR_THREAD_WORKERS`를 2로 낮춰 측정하고, 운영 코드는 수정하지 않습니다.
+
+```bash
+python tests/regression/timetable/measure_timetable_ocr_baseline.py --profile oci-constrained --repeat 1
+```
+
+정확한 OCI 기준선은 실제 OCI 서버에서 측정한 `production` 프로필 결과를 우선합니다. `oci-constrained`는 로컬에서 성능 회귀 위험을 보수적으로 보는 보조 지표입니다.
 
 ### Text Filtering Quality Metrics
 

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -14,6 +14,7 @@ python tests/regression/chatbot/evaluate_rag_retrieval.py
 python tests/regression/chatbot/check_chatbot_tool_routing.py
 python tests/regression/timetable/check_timetable_ocr_diagnostics.py
 python tests/regression/timetable/measure_timetable_ocr_baseline.py
+python tests/regression/timetable/analyze_timetable_empty_cell_skip.py
 python tests/regression/text_filtering/check_text_filter_quality_report.py
 ```
 
@@ -62,6 +63,7 @@ python tests/regression/text_filtering/check_text_filter_quality_report.py
 - `average_grid_detection_duration_ms`, `max_grid_detection_duration_ms`: 격자 검출 시간 기준선
 - `average_ocr_duration_ms`, `max_ocr_duration_ms`: Tesseract OCR 시간 기준선
 - `total_extracted_schedule_count`: 추출된 시간표 항목 수 합계
+- `ocr_task_cell_count`, `skipped_empty_cell_count`: 실제 Tesseract 대상 셀 수와 빈 셀 스킵 수
 - `failure_count`, `failure_reasons`: 실패 사유 관측치
 
 기본 리포트는 `tests/reports/timetable/timetable_ocr_performance_baseline.json`에 저장됩니다. `data/`가 로컬/운영 샘플 영역이라 이미지 파일이 없는 케이스는 전체 실패 대신 개별 `skipped` 케이스로 기록합니다. OCI에서는 부하를 낮추기 위해 기본 `--repeat 1`을 권장하고, 안정적인 비교가 필요할 때만 반복 횟수를 늘립니다.
@@ -79,6 +81,18 @@ python tests/regression/timetable/measure_timetable_ocr_baseline.py --profile oc
 ```
 
 정확한 OCI 기준선은 실제 OCI 서버에서 측정한 `production` 프로필 결과를 우선합니다. `oci-constrained`는 로컬에서 성능 회귀 위험을 보수적으로 보는 보조 지표입니다.
+
+### Timetable OCR Empty-Cell Skip Analysis
+
+`tests/regression/timetable/analyze_timetable_empty_cell_skip.py`는 빈 셀 OCR 스킵을 운영에 적용하기 전에 셀 foreground density threshold 후보를 dry-run으로 분석합니다. 현재 격자/ROI/OCR 판정 함수를 그대로 사용하되 런타임 동작은 바꾸지 않고, threshold별로 OCR 전에 스킵했을 셀 수와 이미 accepted로 판정되는 셀이 스킵 후보에 포함되는지 기록합니다.
+
+- `would_skip_cell_count`: threshold 적용 시 OCR 전에 건너뛰었을 셀 수
+- `would_skip_accepted_cell_count`: 현재 OCR에서 accepted인 셀이 스킵 후보에 들어간 수
+- `would_skip_text_cell_count`: 현재 OCR에서 비어 있지 않은 셀이 스킵 후보에 들어간 수
+- `best_safe_threshold_no_accepted_loss`: 샘플 기준 accepted 셀 손실이 없는 가장 높은 threshold
+- `best_safe_threshold_no_text_loss`: 샘플 기준 OCR 텍스트 셀 손실이 없는 가장 높은 threshold
+
+기본 리포트는 `tests/reports/timetable/timetable_ocr_empty_cell_skip_analysis.json`에 저장됩니다. 이 리포트에서 `would_skip_accepted_cell_count`가 0인 보수적 threshold를 확인한 뒤에만 운영 OCR 스킵 로직을 적용합니다.
 
 ### Text Filtering Quality Metrics
 

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -85,13 +85,14 @@ python tests/regression/timetable/measure_timetable_ocr_baseline.py --profile oc
 
 ### Timetable OCR Empty-Cell Skip Analysis
 
-`tests/regression/timetable/analyze_timetable_empty_cell_skip.py`는 빈 셀 OCR 스킵을 운영에 적용하기 전에 셀 foreground density threshold 후보를 dry-run으로 분석합니다. 현재 격자/ROI/OCR 판정 함수를 그대로 사용하되 런타임 동작은 바꾸지 않고, threshold별로 OCR 전에 스킵했을 셀 수와 이미 accepted로 판정되는 셀이 스킵 후보에 포함되는지 기록합니다.
+`tests/regression/timetable/analyze_timetable_empty_cell_skip.py`는 빈 셀 OCR 스킵을 운영에 적용하기 전에 셀 foreground density threshold와 text-presence detector 후보를 dry-run으로 분석합니다. 현재 격자/ROI/OCR 판정 함수를 그대로 사용하되 런타임 동작은 바꾸지 않고, threshold별로 OCR 전에 스킵했을 셀 수와 이미 accepted로 판정되는 셀이 스킵 후보에 포함되는지 기록합니다.
 
 - `would_skip_cell_count`: threshold 적용 시 OCR 전에 건너뛰었을 셀 수
 - `would_skip_accepted_cell_count`: 현재 OCR에서 accepted인 셀이 스킵 후보에 들어간 수
 - `would_skip_text_cell_count`: 현재 OCR에서 비어 있지 않은 셀이 스킵 후보에 들어간 수
 - `best_safe_threshold_no_accepted_loss`: 샘플 기준 accepted 셀 손실이 없는 가장 높은 threshold
 - `best_safe_threshold_no_text_loss`: 샘플 기준 OCR 텍스트 셀 손실이 없는 가장 높은 threshold
+- `text_presence_estimated_ocr_task_count`: OpenCV text-presence detector 적용 시 예상 OCR 대상 셀 수
 
 기본 리포트는 `tests/reports/timetable/timetable_ocr_empty_cell_skip_analysis.json`에 저장됩니다. 이 리포트에서 `would_skip_accepted_cell_count`가 0인 보수적 threshold를 확인한 뒤에만 운영 OCR 스킵 로직을 적용합니다.
 

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -52,6 +52,7 @@ python tests/regression/text_filtering/check_text_filter_quality_report.py
 - `average_empty_cell_ratio`: OCR 대상 셀 중 텍스트가 없는 셀 비율 평균
 - `average_ocr_confidence`: 진단 OCR confidence 평균
 - `fallback_cell_count`: fallback OCR 경로가 선택된 셀 수
+- `skipped_empty_cell_count`: OCR 전에 빈 셀 후보로 건너뛴 셀 수
 
 `cv2`, `pytesseract`, Tesseract 런타임이 없는 환경에서는 실패 대신 `status: "skipped"` 리포트를 기본 경로에 기록합니다.
 

--- a/tests/regression/timetable/analyze_timetable_empty_cell_skip.py
+++ b/tests/regression/timetable/analyze_timetable_empty_cell_skip.py
@@ -3,7 +3,6 @@ import argparse
 import importlib
 import json
 import sys
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -116,6 +115,15 @@ def resolve_case_path(path_value: str) -> Path:
     return ROOT_DIR / path
 
 
+def classify_final_ocr_status(lines: List[str], ocr_engine) -> str:
+    if not lines:
+        return "empty"
+    reason = ocr_engine._reject_reason_for_lines(lines)
+    if reason is None:
+        return "accepted"
+    return f"rejected_{reason}"
+
+
 def prepare_cell_candidates(img, cv2, ocr_engine) -> Dict[str, Any]:
     base_gray = ocr_engine._make_base_gray(img)
     x_lines, vertical_mask = ocr_engine._vertical_lines(base_gray)
@@ -135,13 +143,15 @@ def prepare_cell_candidates(img, cv2, ocr_engine) -> Dict[str, Any]:
     cells: List[Dict[str, Any]] = []
     tasks: List[bytes] = []
     task_indexes: List[int] = []
+    foreground_density_map: List[float] = []
     for row, col, roi_gray in ocr_engine._iterate_cells_autogrid(base_gray, x_lines, y_lines):
         if row == 0:
             continue
+        foreground_density = ocr_engine._foreground_density(roi_gray)
         cell = {
             "row": row,
             "col": col + 1,
-            "foreground_density": ocr_engine._foreground_density(roi_gray),
+            "foreground_density": foreground_density,
             "text_component_count": ocr_engine._text_component_count(roi_gray),
             "text_presence": ocr_engine._has_text_presence(roi_gray),
             "ocr_status": "not_run",
@@ -150,27 +160,23 @@ def prepare_cell_candidates(img, cv2, ocr_engine) -> Dict[str, Any]:
         if ok:
             tasks.append(buf.tobytes())
             task_indexes.append(len(cells))
+            foreground_density_map.append(foreground_density)
         else:
             cell["ocr_status"] = "roi_encode_failed"
         cells.append(cell)
 
+    runtime_ocr_metrics = {
+        "runtime_fallback_candidates": 0,
+        "runtime_fallback_attempted_cells": 0,
+    }
     if tasks:
-        max_workers = min(ocr_engine.OCR_THREAD_WORKERS, len(tasks)) or 1
-        with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="empty_cell_analysis") as executor:
-            for index, lines in zip(task_indexes, executor.map(ocr_engine._ocr_task, tasks)):
-                cells[index]["lines"] = lines
-                if not lines:
-                    cells[index]["ocr_status"] = "empty"
-                    continue
-                course = lines[0]
-                professor = lines[1] if len(lines) > 1 else ""
-                room = lines[2] if len(lines) > 2 else ""
-                if len(course) > 15 or len(professor) > 8 or len(room) > 10:
-                    cells[index]["ocr_status"] = "rejected_field_too_long"
-                elif ocr_engine._is_valid_course(course) and ocr_engine._is_valid_professor(professor):
-                    cells[index]["ocr_status"] = "accepted"
-                else:
-                    cells[index]["ocr_status"] = "rejected_invalid_course_or_professor"
+        ocr_results, runtime_ocr_metrics = ocr_engine._run_runtime_ocr_with_fallback(tasks, foreground_density_map)
+        for index, ocr_result in zip(task_indexes, ocr_results):
+            lines = ocr_result.get("lines") or []
+            cells[index]["lines"] = lines
+            cells[index]["ocr_config"] = ocr_result.get("config")
+            cells[index]["fallback_used"] = bool(ocr_result.get("fallback_used"))
+            cells[index]["ocr_status"] = classify_final_ocr_status(lines, ocr_engine)
 
     return {
         "grid": {
@@ -179,6 +185,7 @@ def prepare_cell_candidates(img, cv2, ocr_engine) -> Dict[str, Any]:
             "cell_columns": max(0, len(x_lines) - 1),
             "cell_rows": max(0, len(y_lines) - 1),
         },
+        "runtime_ocr_metrics": runtime_ocr_metrics,
         "cells": cells,
     }
 
@@ -204,6 +211,8 @@ def summarize_thresholds(cells: List[Dict[str, Any]], thresholds: List[float], s
                     "row": cell["row"],
                     "col": cell["col"],
                     "foreground_density": cell["foreground_density"],
+                    "ocr_config": cell.get("ocr_config"),
+                    "fallback_used": bool(cell.get("fallback_used")),
                 }
                 for cell in skipped_accepted[:sample_limit]
             ],
@@ -284,6 +293,13 @@ def evaluate_case(case: Dict[str, Any], thresholds: List[float], sample_limit: i
             "accepted_cell_count": accepted_count,
             "text_cell_count": text_count,
             "empty_cell_count": empty_count,
+            "runtime_fallback_candidate_count": int(
+                prepared.get("runtime_ocr_metrics", {}).get("runtime_fallback_candidates", 0)
+            ),
+            "runtime_fallback_attempted_cell_count": int(
+                prepared.get("runtime_ocr_metrics", {}).get("runtime_fallback_attempted_cells", 0)
+            ),
+            "runtime_fallback_accepted_cell_count": sum(1 for cell in cells if cell.get("fallback_used")),
             "best_safe_threshold_no_accepted_loss": max(safe_thresholds) if safe_thresholds else None,
             "best_safe_threshold_no_text_loss": max(no_text_loss_thresholds) if no_text_loss_thresholds else None,
             "text_presence_would_skip_cell_count": len(text_presence_skipped),
@@ -336,6 +352,18 @@ def aggregate_metrics(case_results: List[Dict[str, Any]], thresholds: List[float
         "accepted_cell_count": sum(int(result.get("metrics", {}).get("accepted_cell_count", 0)) for result in passed_results),
         "text_cell_count": sum(int(result.get("metrics", {}).get("text_cell_count", 0)) for result in passed_results),
         "empty_cell_count": sum(int(result.get("metrics", {}).get("empty_cell_count", 0)) for result in passed_results),
+        "runtime_fallback_candidate_count": sum(
+            int(result.get("metrics", {}).get("runtime_fallback_candidate_count", 0))
+            for result in passed_results
+        ),
+        "runtime_fallback_attempted_cell_count": sum(
+            int(result.get("metrics", {}).get("runtime_fallback_attempted_cell_count", 0))
+            for result in passed_results
+        ),
+        "runtime_fallback_accepted_cell_count": sum(
+            int(result.get("metrics", {}).get("runtime_fallback_accepted_cell_count", 0))
+            for result in passed_results
+        ),
         "best_safe_threshold_no_accepted_loss": max(safe_thresholds) if safe_thresholds else None,
         "best_safe_threshold_no_text_loss": max(no_text_loss_thresholds) if no_text_loss_thresholds else None,
         "threshold_summary": threshold_summary,

--- a/tests/regression/timetable/analyze_timetable_empty_cell_skip.py
+++ b/tests/regression/timetable/analyze_timetable_empty_cell_skip.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+import argparse
+import importlib
+import json
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+DEFAULT_CASES_PATH = ROOT_DIR / "tests" / "regression" / "timetable" / "timetable_ocr_performance_cases.json"
+DEFAULT_REPORT_PATH = ROOT_DIR / "tests" / "reports" / "timetable" / "timetable_ocr_empty_cell_skip_analysis.json"
+DEFAULT_THRESHOLDS = "0.001,0.002,0.003,0.005,0.008,0.01,0.015,0.02,0.03,0.05,0.075,0.1"
+SUITE = "timetable_ocr_empty_cell_skip_analysis"
+SERVICE = "timetable"
+
+
+def load_cases(path: Path) -> Dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    cases = payload.get("cases", [])
+    if not isinstance(cases, list) or not cases:
+        raise ValueError(f"no timetable OCR performance cases found in {path}")
+    return payload
+
+
+def write_report(out_path: Path, output: Dict[str, Any]) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(output, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def make_summary(
+    status: str,
+    total: int,
+    passed: int,
+    failed: int,
+    skipped: int,
+    metrics: Dict[str, Any],
+    errors: List[str],
+) -> Dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "suite": SUITE,
+        "service": SERVICE,
+        "status": status,
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "skipped": skipped,
+        "metrics": metrics,
+        "errors": errors,
+    }
+
+
+def write_skipped_report(out_path: Path, reason: str, cases_path: Path) -> None:
+    summary = make_summary(
+        status="skipped",
+        total=0,
+        passed=0,
+        failed=0,
+        skipped=1,
+        metrics={},
+        errors=[],
+    )
+    output = {
+        "schema_version": 1,
+        "suite": SUITE,
+        "service": SERVICE,
+        "summary": summary,
+        "cases_path": str(cases_path),
+        "skipped": {
+            "reason": reason,
+        },
+        "case_results": [],
+    }
+    write_report(out_path, output)
+    print(f"[SKIP] {reason}")
+    print(json.dumps(summary, ensure_ascii=False))
+    print(f"report={out_path}")
+
+
+def load_ocr_dependencies(out_path: Path, cases_path: Path):
+    try:
+        cv2 = importlib.import_module("cv2")
+        pytesseract = importlib.import_module("pytesseract")
+        ocr_engine = importlib.import_module("image_analysis.ocr_engine")
+    except ModuleNotFoundError as exc:
+        write_skipped_report(out_path, f"timetable OCR empty-cell analysis dependency is missing: {exc.name}", cases_path)
+        raise SystemExit(0) from exc
+
+    try:
+        pytesseract.get_tesseract_version()
+    except Exception as exc:
+        write_skipped_report(out_path, f"Tesseract runtime is unavailable: {exc}", cases_path)
+        raise SystemExit(0) from exc
+
+    return cv2, ocr_engine
+
+
+def parse_thresholds(value: str) -> List[float]:
+    thresholds = sorted({float(item.strip()) for item in value.split(",") if item.strip()})
+    if not thresholds:
+        raise ValueError("--thresholds must include at least one value")
+    if any(threshold < 0 for threshold in thresholds):
+        raise ValueError("--thresholds values must be non-negative")
+    return thresholds
+
+
+def resolve_case_path(path_value: str) -> Path:
+    path = Path(path_value)
+    if path.is_absolute():
+        return path
+    return ROOT_DIR / path
+
+
+def prepare_cell_candidates(img, cv2, ocr_engine) -> Dict[str, Any]:
+    base_gray = ocr_engine._make_base_gray(img)
+    x_lines, vertical_mask = ocr_engine._vertical_lines(base_gray)
+    x_lines = ocr_engine._prune_x_lines(x_lines, base_gray)
+    y_lines, horizontal_mask = ocr_engine._horizontal_lines(base_gray, vertical_mask=vertical_mask)
+
+    if ocr_engine.TRIM_OUTER:
+        if len(x_lines) > 2 and (x_lines[1] - x_lines[0] < ocr_engine.TRIM_X_GAP):
+            x_lines = x_lines[1:]
+        if len(x_lines) > 2 and (x_lines[-1] - x_lines[-2] < ocr_engine.TRIM_X_GAP):
+            x_lines = x_lines[:-1]
+        if len(y_lines) > 2 and (y_lines[1] - y_lines[0] < ocr_engine.TRIM_Y_GAP):
+            y_lines = y_lines[1:]
+        if len(y_lines) > 2 and (y_lines[-1] - y_lines[-2] < ocr_engine.TRIM_Y_GAP):
+            y_lines = y_lines[:-1]
+
+    cells: List[Dict[str, Any]] = []
+    tasks: List[bytes] = []
+    task_indexes: List[int] = []
+    for row, col, roi_gray in ocr_engine._iterate_cells_autogrid(base_gray, x_lines, y_lines):
+        if row == 0:
+            continue
+        cell = {
+            "row": row,
+            "col": col + 1,
+            "foreground_density": ocr_engine._foreground_density(roi_gray),
+            "ocr_status": "not_run",
+        }
+        ok, buf = cv2.imencode(".png", roi_gray)
+        if ok:
+            tasks.append(buf.tobytes())
+            task_indexes.append(len(cells))
+        else:
+            cell["ocr_status"] = "roi_encode_failed"
+        cells.append(cell)
+
+    if tasks:
+        max_workers = min(ocr_engine.OCR_THREAD_WORKERS, len(tasks)) or 1
+        with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="empty_cell_analysis") as executor:
+            for index, lines in zip(task_indexes, executor.map(ocr_engine._ocr_task, tasks)):
+                cells[index]["lines"] = lines
+                if not lines:
+                    cells[index]["ocr_status"] = "empty"
+                    continue
+                course = lines[0]
+                professor = lines[1] if len(lines) > 1 else ""
+                room = lines[2] if len(lines) > 2 else ""
+                if len(course) > 15 or len(professor) > 8 or len(room) > 10:
+                    cells[index]["ocr_status"] = "rejected_field_too_long"
+                elif ocr_engine._is_valid_course(course) and ocr_engine._is_valid_professor(professor):
+                    cells[index]["ocr_status"] = "accepted"
+                else:
+                    cells[index]["ocr_status"] = "rejected_invalid_course_or_professor"
+
+    return {
+        "grid": {
+            "x_line_count": len(x_lines),
+            "y_line_count": len(y_lines),
+            "cell_columns": max(0, len(x_lines) - 1),
+            "cell_rows": max(0, len(y_lines) - 1),
+        },
+        "cells": cells,
+    }
+
+
+def summarize_thresholds(cells: List[Dict[str, Any]], thresholds: List[float], sample_limit: int) -> List[Dict[str, Any]]:
+    accepted_cells = [cell for cell in cells if cell.get("ocr_status") == "accepted"]
+    text_cells = [cell for cell in cells if cell.get("ocr_status") not in {"empty", "roi_encode_failed", "not_run"}]
+    results: List[Dict[str, Any]] = []
+    for threshold in thresholds:
+        skipped = [cell for cell in cells if float(cell["foreground_density"]) <= threshold]
+        skipped_accepted = [cell for cell in skipped if cell.get("ocr_status") == "accepted"]
+        skipped_text = [cell for cell in skipped if cell.get("ocr_status") not in {"empty", "roi_encode_failed", "not_run"}]
+        results.append({
+            "threshold": threshold,
+            "would_skip_cell_count": len(skipped),
+            "would_skip_cell_ratio": round(len(skipped) / len(cells), 4) if cells else 0.0,
+            "would_skip_accepted_cell_count": len(skipped_accepted),
+            "would_skip_text_cell_count": len(skipped_text),
+            "estimated_ocr_task_count_after_skip": max(0, len(cells) - len(skipped)),
+            "estimated_ocr_task_reduction_ratio": round(len(skipped) / len(cells), 4) if cells else 0.0,
+            "sample_skipped_accepted_cells": [
+                {
+                    "row": cell["row"],
+                    "col": cell["col"],
+                    "foreground_density": cell["foreground_density"],
+                }
+                for cell in skipped_accepted[:sample_limit]
+            ],
+        })
+
+    accepted_densities = [float(cell["foreground_density"]) for cell in accepted_cells]
+    text_densities = [float(cell["foreground_density"]) for cell in text_cells]
+    if accepted_densities:
+        results.append({
+            "threshold": "accepted_density_floor",
+            "min_accepted_foreground_density": min(accepted_densities),
+            "max_accepted_foreground_density": max(accepted_densities),
+            "min_text_foreground_density": min(text_densities) if text_densities else None,
+        })
+    return results
+
+
+def evaluate_case(case: Dict[str, Any], thresholds: List[float], sample_limit: int, cv2, ocr_engine) -> Dict[str, Any]:
+    case_id = str(case.get("id") or case.get("path") or "unnamed_case")
+    path_value = str(case.get("path") or "")
+    image_path = resolve_case_path(path_value)
+    result: Dict[str, Any] = {
+        "id": case_id,
+        "path": path_value,
+        "absolute_path": str(image_path),
+    }
+
+    if not image_path.exists():
+        result.update({
+            "status": "skipped",
+            "reason": "image_not_found",
+            "metrics": {},
+            "threshold_results": [],
+        })
+        return result
+
+    image = cv2.imread(str(image_path))
+    if image is None:
+        result.update({
+            "status": "failed",
+            "errors": ["image_decode_failed"],
+            "metrics": {},
+            "threshold_results": [],
+        })
+        return result
+
+    prepared = prepare_cell_candidates(image, cv2, ocr_engine)
+    cells = prepared["cells"]
+    threshold_results = summarize_thresholds(cells, thresholds, sample_limit)
+    accepted_count = sum(1 for cell in cells if cell.get("ocr_status") == "accepted")
+    empty_count = sum(1 for cell in cells if cell.get("ocr_status") == "empty")
+    text_count = sum(1 for cell in cells if cell.get("ocr_status") not in {"empty", "roi_encode_failed", "not_run"})
+    safe_thresholds = [
+        item["threshold"]
+        for item in threshold_results
+        if isinstance(item["threshold"], float)
+        and item["would_skip_accepted_cell_count"] == 0
+    ]
+    no_text_loss_thresholds = [
+        item["threshold"]
+        for item in threshold_results
+        if isinstance(item["threshold"], float)
+        and item["would_skip_text_cell_count"] == 0
+    ]
+
+    result.update({
+        "status": "passed",
+        "grid": prepared["grid"],
+        "metrics": {
+            "total_cell_count": len(cells),
+            "accepted_cell_count": accepted_count,
+            "text_cell_count": text_count,
+            "empty_cell_count": empty_count,
+            "best_safe_threshold_no_accepted_loss": max(safe_thresholds) if safe_thresholds else None,
+            "best_safe_threshold_no_text_loss": max(no_text_loss_thresholds) if no_text_loss_thresholds else None,
+        },
+        "threshold_results": threshold_results,
+    })
+    return result
+
+
+def aggregate_metrics(case_results: List[Dict[str, Any]], thresholds: List[float]) -> Dict[str, Any]:
+    passed_results = [result for result in case_results if result.get("status") == "passed"]
+    threshold_summary: List[Dict[str, Any]] = []
+    for threshold in thresholds:
+        items = [
+            item
+            for result in passed_results
+            for item in result.get("threshold_results", [])
+            if item.get("threshold") == threshold
+        ]
+        total_cells = sum(int(result.get("metrics", {}).get("total_cell_count", 0)) for result in passed_results)
+        skipped = sum(int(item.get("would_skip_cell_count", 0)) for item in items)
+        skipped_accepted = sum(int(item.get("would_skip_accepted_cell_count", 0)) for item in items)
+        skipped_text = sum(int(item.get("would_skip_text_cell_count", 0)) for item in items)
+        threshold_summary.append({
+            "threshold": threshold,
+            "would_skip_cell_count": skipped,
+            "would_skip_cell_ratio": round(skipped / total_cells, 4) if total_cells else 0.0,
+            "would_skip_accepted_cell_count": skipped_accepted,
+            "would_skip_text_cell_count": skipped_text,
+            "safe_no_accepted_loss": skipped_accepted == 0,
+        })
+
+    safe_thresholds = [
+        item["threshold"]
+        for item in threshold_summary
+        if item["safe_no_accepted_loss"]
+    ]
+    no_text_loss_thresholds = [
+        item["threshold"]
+        for item in threshold_summary
+        if item["would_skip_text_cell_count"] == 0
+    ]
+    return {
+        "measured_case_count": len(passed_results),
+        "total_cell_count": sum(int(result.get("metrics", {}).get("total_cell_count", 0)) for result in passed_results),
+        "accepted_cell_count": sum(int(result.get("metrics", {}).get("accepted_cell_count", 0)) for result in passed_results),
+        "text_cell_count": sum(int(result.get("metrics", {}).get("text_cell_count", 0)) for result in passed_results),
+        "empty_cell_count": sum(int(result.get("metrics", {}).get("empty_cell_count", 0)) for result in passed_results),
+        "best_safe_threshold_no_accepted_loss": max(safe_thresholds) if safe_thresholds else None,
+        "best_safe_threshold_no_text_loss": max(no_text_loss_thresholds) if no_text_loss_thresholds else None,
+        "threshold_summary": threshold_summary,
+        "skipped_case_count": sum(1 for result in case_results if result.get("status") == "skipped"),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Analyze candidate blank-cell thresholds before changing timetable OCR runtime")
+    parser.add_argument("--cases", default=str(DEFAULT_CASES_PATH), help="performance cases path")
+    parser.add_argument("--out", default=str(DEFAULT_REPORT_PATH), help="output report path")
+    parser.add_argument("--thresholds", default=DEFAULT_THRESHOLDS, help="comma-separated foreground-density thresholds")
+    parser.add_argument("--sample-limit", type=int, default=8, help="max skipped accepted-cell samples per threshold")
+    args = parser.parse_args()
+
+    if args.sample_limit < 0:
+        raise ValueError("--sample-limit must be non-negative")
+
+    out_path = Path(args.out)
+    cases_path = Path(args.cases)
+    thresholds = parse_thresholds(args.thresholds)
+    case_payload = load_cases(cases_path)
+    cases = case_payload["cases"]
+    cv2, ocr_engine = load_ocr_dependencies(out_path, cases_path)
+
+    case_results = [evaluate_case(case, thresholds, args.sample_limit, cv2, ocr_engine) for case in cases]
+    errors = [
+        f"{result['id']}:{error}"
+        for result in case_results
+        for error in result.get("errors", [])
+    ]
+    failed = sum(1 for result in case_results if result.get("status") == "failed")
+    skipped = sum(1 for result in case_results if result.get("status") == "skipped")
+    passed = len(case_results) - failed - skipped
+    status = "failed" if failed else "passed"
+    summary = make_summary(
+        status=status,
+        total=len(case_results),
+        passed=passed,
+        failed=failed,
+        skipped=skipped,
+        metrics=aggregate_metrics(case_results, thresholds),
+        errors=errors,
+    )
+    output = {
+        "schema_version": 1,
+        "suite": SUITE,
+        "service": SERVICE,
+        "summary": summary,
+        "cases_path": str(cases_path),
+        "thresholds": thresholds,
+        "measured_at": datetime.now(timezone.utc).isoformat(),
+        "notes": [
+            "This is a dry-run analysis only. It does not change runtime OCR behavior.",
+            "A threshold is considered safer when would_skip_accepted_cell_count remains 0 across the sample set.",
+        ],
+        "case_results": case_results,
+    }
+    write_report(out_path, output)
+
+    for result in case_results:
+        if result.get("status") == "skipped":
+            print(f"[SKIP] {result['id']} {result.get('reason')}")
+    if failed:
+        for error in errors:
+            print(f"[FAIL] {error}")
+        print(json.dumps(summary, ensure_ascii=False))
+        print(f"report={out_path}")
+        return 1
+
+    print("[OK] timetable OCR empty-cell skip analysis")
+    print(json.dumps(summary, ensure_ascii=False))
+    print(f"report={out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/regression/timetable/analyze_timetable_empty_cell_skip.py
+++ b/tests/regression/timetable/analyze_timetable_empty_cell_skip.py
@@ -142,6 +142,8 @@ def prepare_cell_candidates(img, cv2, ocr_engine) -> Dict[str, Any]:
             "row": row,
             "col": col + 1,
             "foreground_density": ocr_engine._foreground_density(roi_gray),
+            "text_component_count": ocr_engine._text_component_count(roi_gray),
+            "text_presence": ocr_engine._has_text_presence(roi_gray),
             "ocr_status": "not_run",
         }
         ok, buf = cv2.imencode(".png", roi_gray)
@@ -254,6 +256,13 @@ def evaluate_case(case: Dict[str, Any], thresholds: List[float], sample_limit: i
     accepted_count = sum(1 for cell in cells if cell.get("ocr_status") == "accepted")
     empty_count = sum(1 for cell in cells if cell.get("ocr_status") == "empty")
     text_count = sum(1 for cell in cells if cell.get("ocr_status") not in {"empty", "roi_encode_failed", "not_run"})
+    text_presence_skipped = [cell for cell in cells if not cell.get("text_presence")]
+    text_presence_skipped_accepted = [cell for cell in text_presence_skipped if cell.get("ocr_status") == "accepted"]
+    text_presence_skipped_text = [
+        cell
+        for cell in text_presence_skipped
+        if cell.get("ocr_status") not in {"empty", "roi_encode_failed", "not_run"}
+    ]
     safe_thresholds = [
         item["threshold"]
         for item in threshold_results
@@ -277,6 +286,11 @@ def evaluate_case(case: Dict[str, Any], thresholds: List[float], sample_limit: i
             "empty_cell_count": empty_count,
             "best_safe_threshold_no_accepted_loss": max(safe_thresholds) if safe_thresholds else None,
             "best_safe_threshold_no_text_loss": max(no_text_loss_thresholds) if no_text_loss_thresholds else None,
+            "text_presence_would_skip_cell_count": len(text_presence_skipped),
+            "text_presence_would_skip_cell_ratio": round(len(text_presence_skipped) / len(cells), 4) if cells else 0.0,
+            "text_presence_would_skip_accepted_cell_count": len(text_presence_skipped_accepted),
+            "text_presence_would_skip_text_cell_count": len(text_presence_skipped_text),
+            "text_presence_estimated_ocr_task_count": max(0, len(cells) - len(text_presence_skipped)),
         },
         "threshold_results": threshold_results,
     })
@@ -325,6 +339,22 @@ def aggregate_metrics(case_results: List[Dict[str, Any]], thresholds: List[float
         "best_safe_threshold_no_accepted_loss": max(safe_thresholds) if safe_thresholds else None,
         "best_safe_threshold_no_text_loss": max(no_text_loss_thresholds) if no_text_loss_thresholds else None,
         "threshold_summary": threshold_summary,
+        "text_presence_would_skip_cell_count": sum(
+            int(result.get("metrics", {}).get("text_presence_would_skip_cell_count", 0))
+            for result in passed_results
+        ),
+        "text_presence_would_skip_accepted_cell_count": sum(
+            int(result.get("metrics", {}).get("text_presence_would_skip_accepted_cell_count", 0))
+            for result in passed_results
+        ),
+        "text_presence_would_skip_text_cell_count": sum(
+            int(result.get("metrics", {}).get("text_presence_would_skip_text_cell_count", 0))
+            for result in passed_results
+        ),
+        "text_presence_estimated_ocr_task_count": sum(
+            int(result.get("metrics", {}).get("text_presence_estimated_ocr_task_count", 0))
+            for result in passed_results
+        ),
         "skipped_case_count": sum(1 for result in case_results if result.get("status") == "skipped"),
     }
 

--- a/tests/regression/timetable/check_timetable_ocr_diagnostics.py
+++ b/tests/regression/timetable/check_timetable_ocr_diagnostics.py
@@ -154,7 +154,7 @@ def grid_detection_success(grid: Dict[str, Any], expected: Dict[str, Any]) -> bo
 
 
 def empty_cell_ratio(ocr: Dict[str, Any]) -> Optional[float]:
-    total = int(ocr.get("total_cells", 0))
+    total = int(ocr.get("ocr_task_cells", 0) or ocr.get("total_cells", 0))
     if total <= 0:
         return None
     text_cells = int(ocr.get("text_cells", 0))
@@ -189,6 +189,7 @@ def evaluate_case(case: Dict[str, Any], cv2, np, ocr_engine) -> Dict[str, Any]:
         "empty_cell_ratio": empty_cell_ratio(ocr),
         "ocr_confidence": ocr.get("average_confidence"),
         "fallback_cell_count": ocr.get("fallback_cells", 0),
+        "skipped_empty_cell_count": ocr.get("skipped_empty_cells", 0),
         "accepted_cell_count": ocr.get("accepted_cells", 0),
         "rejected_cell_count": len(ocr.get("rejected_cells", [])),
         "low_confidence_cell_count": ocr.get("low_confidence_cells", 0),
@@ -241,6 +242,7 @@ def aggregate_metrics(case_results: List[Dict[str, Any]]) -> Dict[str, Any]:
         "average_empty_cell_ratio": round(sum(empty_ratios) / len(empty_ratios), 4) if empty_ratios else None,
         "average_ocr_confidence": round(sum(confidence_values) / len(confidence_values), 2) if confidence_values else None,
         "fallback_cell_count": sum(int(result["metrics"].get("fallback_cell_count", 0)) for result in case_results),
+        "skipped_empty_cell_count": sum(int(result["metrics"].get("skipped_empty_cell_count", 0)) for result in case_results),
         "accepted_cell_count": sum(int(result["metrics"].get("accepted_cell_count", 0)) for result in case_results),
         "rejected_cell_count": sum(int(result["metrics"].get("rejected_cell_count", 0)) for result in case_results),
     }

--- a/tests/regression/timetable/check_timetable_ocr_diagnostics.py
+++ b/tests/regression/timetable/check_timetable_ocr_diagnostics.py
@@ -154,7 +154,10 @@ def grid_detection_success(grid: Dict[str, Any], expected: Dict[str, Any]) -> bo
 
 
 def empty_cell_ratio(ocr: Dict[str, Any]) -> Optional[float]:
-    total = int(ocr.get("ocr_task_cells", 0) or ocr.get("total_cells", 0))
+    total_value = ocr.get("ocr_task_cells")
+    if total_value is None:
+        total_value = ocr.get("total_cells", 0)
+    total = int(total_value or 0)
     if total <= 0:
         return None
     text_cells = int(ocr.get("text_cells", 0))

--- a/tests/regression/timetable/measure_timetable_ocr_baseline.py
+++ b/tests/regression/timetable/measure_timetable_ocr_baseline.py
@@ -341,7 +341,12 @@ def main() -> int:
     failed = sum(1 for result in case_results if result.get("status") == "failed")
     skipped = sum(1 for result in case_results if result.get("status") == "skipped")
     passed = len(case_results) - failed - skipped
-    status = "failed" if failed else "passed"
+    if failed:
+        status = "failed"
+    elif passed == 0 and skipped > 0:
+        status = "skipped"
+    else:
+        status = "passed"
     summary = make_summary(
         status=status,
         total=len(case_results),

--- a/tests/regression/timetable/measure_timetable_ocr_baseline.py
+++ b/tests/regression/timetable/measure_timetable_ocr_baseline.py
@@ -142,6 +142,8 @@ def extract_run_metrics(report: Dict[str, Any]) -> Dict[str, Any]:
         "text_cell_count": int(ocr.get("text_cells", 0) or 0),
         "skipped_empty_cell_count": int(ocr.get("skipped_empty_cells", 0) or 0),
         "fallback_cell_count": int(ocr.get("fallback_cells", 0) or 0),
+        "runtime_fallback_candidate_count": int(ocr.get("runtime_fallback_candidates", 0) or 0),
+        "runtime_fallback_attempted_cell_count": int(ocr.get("runtime_fallback_attempted_cells", 0) or 0),
     }
 
 
@@ -171,6 +173,8 @@ def summarize_runs(runs: List[Dict[str, Any]]) -> Dict[str, Any]:
         "text_cell_count": first_run.get("text_cell_count"),
         "skipped_empty_cell_count": first_run.get("skipped_empty_cell_count"),
         "fallback_cell_count": first_run.get("fallback_cell_count"),
+        "runtime_fallback_candidate_count": first_run.get("runtime_fallback_candidate_count"),
+        "runtime_fallback_attempted_cell_count": first_run.get("runtime_fallback_attempted_cell_count"),
     }
 
 
@@ -287,6 +291,9 @@ def aggregate_metrics(case_results: List[Dict[str, Any]]) -> Dict[str, Any]:
         "total_cell_count": sum(int(run.get("total_cell_count", 0)) for run in runs),
         "ocr_task_cell_count": sum(int(run.get("ocr_task_cell_count", 0)) for run in runs),
         "skipped_empty_cell_count": sum(int(run.get("skipped_empty_cell_count", 0)) for run in runs),
+        "fallback_cell_count": sum(int(run.get("fallback_cell_count", 0)) for run in runs),
+        "runtime_fallback_candidate_count": sum(int(run.get("runtime_fallback_candidate_count", 0)) for run in runs),
+        "runtime_fallback_attempted_cell_count": sum(int(run.get("runtime_fallback_attempted_cell_count", 0)) for run in runs),
         "failure_count": len(failure_reasons),
         "failure_reasons": sorted(set(failure_reasons)),
         "skipped_case_count": sum(1 for result in case_results if result.get("status") == "skipped"),

--- a/tests/regression/timetable/measure_timetable_ocr_baseline.py
+++ b/tests/regression/timetable/measure_timetable_ocr_baseline.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+import argparse
+import importlib
+import json
+import math
+import os
+import platform
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+DEFAULT_CASES_PATH = ROOT_DIR / "tests" / "regression" / "timetable" / "timetable_ocr_performance_cases.json"
+DEFAULT_REPORT_PATH = ROOT_DIR / "tests" / "reports" / "timetable" / "timetable_ocr_performance_baseline.json"
+SUITE = "timetable_ocr_performance_baseline"
+SERVICE = "timetable"
+
+
+def load_cases(path: Path) -> Dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    cases = payload.get("cases", [])
+    if not isinstance(cases, list) or not cases:
+        raise ValueError(f"no timetable OCR performance cases found in {path}")
+    return payload
+
+
+def write_report(out_path: Path, output: Dict[str, Any]) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(output, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def make_summary(
+    status: str,
+    total: int,
+    passed: int,
+    failed: int,
+    skipped: int,
+    metrics: Dict[str, Any],
+    errors: List[str],
+) -> Dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "suite": SUITE,
+        "service": SERVICE,
+        "status": status,
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "skipped": skipped,
+        "metrics": metrics,
+        "errors": errors,
+    }
+
+
+def write_skipped_report(out_path: Path, reason: str, cases_path: Path) -> None:
+    summary = make_summary(
+        status="skipped",
+        total=0,
+        passed=0,
+        failed=0,
+        skipped=1,
+        metrics={},
+        errors=[],
+    )
+    output = {
+        "schema_version": 1,
+        "suite": SUITE,
+        "service": SERVICE,
+        "summary": summary,
+        "cases_path": str(cases_path),
+        "skipped": {
+            "reason": reason,
+        },
+        "case_results": [],
+    }
+    write_report(out_path, output)
+    print(f"[SKIP] {reason}")
+    print(json.dumps(summary, ensure_ascii=False))
+    print(f"report={out_path}")
+
+
+def load_ocr_dependencies(out_path: Path, cases_path: Path):
+    try:
+        cv2 = importlib.import_module("cv2")
+        pytesseract = importlib.import_module("pytesseract")
+        ocr_engine = importlib.import_module("image_analysis.ocr_engine")
+    except ModuleNotFoundError as exc:
+        write_skipped_report(out_path, f"timetable OCR baseline dependency is missing: {exc.name}", cases_path)
+        raise SystemExit(0) from exc
+
+    try:
+        pytesseract.get_tesseract_version()
+    except Exception as exc:
+        write_skipped_report(out_path, f"Tesseract runtime is unavailable: {exc}", cases_path)
+        raise SystemExit(0) from exc
+
+    return cv2, ocr_engine
+
+
+def percentile(values: List[int], percentile_value: float) -> Optional[int]:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = max(0, min(len(ordered) - 1, math.ceil((percentile_value / 100.0) * len(ordered)) - 1))
+    return ordered[index]
+
+
+def average_int(values: List[int]) -> Optional[int]:
+    if not values:
+        return None
+    return int(round(sum(values) / len(values)))
+
+
+def resolve_case_path(path_value: str) -> Path:
+    path = Path(path_value)
+    if path.is_absolute():
+        return path
+    return ROOT_DIR / path
+
+
+def extract_run_metrics(report: Dict[str, Any]) -> Dict[str, Any]:
+    diagnostics = report.get("diagnostics", {})
+    runtime = diagnostics.get("runtime", {})
+    grid = diagnostics.get("grid", {})
+    ocr = diagnostics.get("ocr", {})
+    schedules = report.get("schedules", [])
+    return {
+        "total_duration_ms": int(runtime.get("total_duration_ms", 0) or 0),
+        "grid_detection_duration_ms": int(runtime.get("grid_detection_duration_ms", 0) or 0),
+        "ocr_duration_ms": int(runtime.get("ocr_duration_ms", 0) or 0),
+        "schedule_count": len(schedules),
+        "failure_reason": diagnostics.get("failure_reason"),
+        "x_line_count": int(grid.get("x_line_count", 0) or 0),
+        "y_line_count": int(grid.get("y_line_count", 0) or 0),
+        "accepted_cell_count": int(ocr.get("accepted_cells", 0) or 0),
+        "total_cell_count": int(ocr.get("total_cells", 0) or 0),
+        "text_cell_count": int(ocr.get("text_cells", 0) or 0),
+        "fallback_cell_count": int(ocr.get("fallback_cells", 0) or 0),
+    }
+
+
+def summarize_runs(runs: List[Dict[str, Any]]) -> Dict[str, Any]:
+    total_durations = [run["total_duration_ms"] for run in runs]
+    grid_durations = [run["grid_detection_duration_ms"] for run in runs]
+    ocr_durations = [run["ocr_duration_ms"] for run in runs]
+    schedule_counts = [run["schedule_count"] for run in runs]
+    failure_reasons = sorted({run["failure_reason"] for run in runs if run.get("failure_reason")})
+    first_run = runs[0] if runs else {}
+    return {
+        "average_total_duration_ms": average_int(total_durations),
+        "max_total_duration_ms": max(total_durations) if total_durations else None,
+        "p95_total_duration_ms": percentile(total_durations, 95.0),
+        "average_grid_detection_duration_ms": average_int(grid_durations),
+        "max_grid_detection_duration_ms": max(grid_durations) if grid_durations else None,
+        "average_ocr_duration_ms": average_int(ocr_durations),
+        "max_ocr_duration_ms": max(ocr_durations) if ocr_durations else None,
+        "average_schedule_count": average_int(schedule_counts),
+        "max_schedule_count": max(schedule_counts) if schedule_counts else None,
+        "failure_reasons": failure_reasons,
+        "x_line_count": first_run.get("x_line_count"),
+        "y_line_count": first_run.get("y_line_count"),
+        "accepted_cell_count": first_run.get("accepted_cell_count"),
+        "total_cell_count": first_run.get("total_cell_count"),
+        "text_cell_count": first_run.get("text_cell_count"),
+        "fallback_cell_count": first_run.get("fallback_cell_count"),
+    }
+
+
+def evaluate_case(case: Dict[str, Any], repeat: int, warmup: int, cv2, ocr_engine) -> Dict[str, Any]:
+    case_id = str(case.get("id") or case.get("path") or "unnamed_case")
+    path_value = str(case.get("path") or "")
+    image_path = resolve_case_path(path_value)
+    result: Dict[str, Any] = {
+        "id": case_id,
+        "path": path_value,
+        "absolute_path": str(image_path),
+    }
+
+    if not image_path.exists():
+        result.update({
+            "status": "skipped",
+            "reason": "image_not_found",
+            "runs": [],
+            "metrics": {},
+        })
+        return result
+
+    image = cv2.imread(str(image_path))
+    if image is None:
+        result.update({
+            "status": "failed",
+            "errors": ["image_decode_failed"],
+            "runs": [],
+            "metrics": {},
+        })
+        return result
+
+    runs: List[Dict[str, Any]] = []
+    errors: List[str] = []
+    for warmup_index in range(warmup):
+        try:
+            ocr_engine.extract_schedule_runtime_report(image)
+        except Exception as exc:
+            errors.append(f"warmup_{warmup_index + 1}:{type(exc).__name__}:{exc}")
+
+    for run_index in range(repeat):
+        try:
+            report = ocr_engine.extract_schedule_runtime_report(image)
+        except Exception as exc:
+            errors.append(f"run_{run_index + 1}:{type(exc).__name__}:{exc}")
+            continue
+        run_metrics = extract_run_metrics(report)
+        run_metrics["run"] = run_index + 1
+        runs.append(run_metrics)
+
+    if errors and not runs:
+        status = "failed"
+    elif errors:
+        status = "failed"
+    else:
+        status = "passed"
+
+    result.update({
+        "status": status,
+        "runs": runs,
+        "metrics": summarize_runs(runs),
+    })
+    if errors:
+        result["errors"] = errors
+    return result
+
+
+def apply_runtime_profile(ocr_engine, profile: str, ocr_workers: Optional[int]) -> Dict[str, Any]:
+    original_ocr_workers = int(getattr(ocr_engine, "OCR_THREAD_WORKERS", 0) or 0)
+    effective_ocr_workers = ocr_workers
+    if effective_ocr_workers is None and profile == "oci-constrained":
+        effective_ocr_workers = 2
+
+    if effective_ocr_workers is not None:
+        if effective_ocr_workers < 1:
+            raise ValueError("--ocr-workers must be at least 1")
+        setattr(ocr_engine, "OCR_THREAD_WORKERS", effective_ocr_workers)
+
+    return {
+        "profile": profile,
+        "original_ocr_thread_workers": original_ocr_workers,
+        "effective_ocr_thread_workers": int(getattr(ocr_engine, "OCR_THREAD_WORKERS", 0) or 0),
+        "process_cpu_count": os.cpu_count(),
+        "platform": platform.platform(),
+        "python_version": platform.python_version(),
+    }
+
+
+def aggregate_metrics(case_results: List[Dict[str, Any]]) -> Dict[str, Any]:
+    runs = [
+        run
+        for result in case_results
+        if result.get("status") == "passed"
+        for run in result.get("runs", [])
+    ]
+    total_durations = [run["total_duration_ms"] for run in runs]
+    grid_durations = [run["grid_detection_duration_ms"] for run in runs]
+    ocr_durations = [run["ocr_duration_ms"] for run in runs]
+    failure_reasons = [
+        run["failure_reason"]
+        for run in runs
+        if run.get("failure_reason")
+    ]
+    return {
+        "measured_run_count": len(runs),
+        "average_total_duration_ms": average_int(total_durations),
+        "max_total_duration_ms": max(total_durations) if total_durations else None,
+        "p95_total_duration_ms": percentile(total_durations, 95.0),
+        "average_grid_detection_duration_ms": average_int(grid_durations),
+        "max_grid_detection_duration_ms": max(grid_durations) if grid_durations else None,
+        "average_ocr_duration_ms": average_int(ocr_durations),
+        "max_ocr_duration_ms": max(ocr_durations) if ocr_durations else None,
+        "total_extracted_schedule_count": sum(int(run.get("schedule_count", 0)) for run in runs),
+        "failure_count": len(failure_reasons),
+        "failure_reasons": sorted(set(failure_reasons)),
+        "skipped_case_count": sum(1 for result in case_results if result.get("status") == "skipped"),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Write a timetable OCR runtime performance baseline report")
+    parser.add_argument("--cases", default=str(DEFAULT_CASES_PATH), help="performance cases path")
+    parser.add_argument("--out", default=str(DEFAULT_REPORT_PATH), help="output report path")
+    parser.add_argument("--repeat", type=int, default=1, help="number of runs per image; keep low on OCI")
+    parser.add_argument("--warmup", type=int, default=0, help="unmeasured warmup runs per image")
+    parser.add_argument(
+        "--profile",
+        choices=("local", "production", "oci-constrained"),
+        default="production",
+        help="measurement profile; oci-constrained defaults OCR cell workers to 2",
+    )
+    parser.add_argument(
+        "--ocr-workers",
+        type=int,
+        default=None,
+        help="override image_analysis.ocr_engine.OCR_THREAD_WORKERS for this measurement process",
+    )
+    args = parser.parse_args()
+
+    if args.repeat < 1:
+        raise ValueError("--repeat must be at least 1")
+    if args.warmup < 0:
+        raise ValueError("--warmup must be at least 0")
+
+    out_path = Path(args.out)
+    cases_path = Path(args.cases)
+    case_payload = load_cases(cases_path)
+    cases = case_payload["cases"]
+    cv2, ocr_engine = load_ocr_dependencies(out_path, cases_path)
+    runtime_profile = apply_runtime_profile(ocr_engine, args.profile, args.ocr_workers)
+
+    case_results = [evaluate_case(case, args.repeat, args.warmup, cv2, ocr_engine) for case in cases]
+    errors = [
+        f"{result['id']}:{error}"
+        for result in case_results
+        for error in result.get("errors", [])
+    ]
+    failed = sum(1 for result in case_results if result.get("status") == "failed")
+    skipped = sum(1 for result in case_results if result.get("status") == "skipped")
+    passed = len(case_results) - failed - skipped
+    status = "failed" if failed else "passed"
+    summary = make_summary(
+        status=status,
+        total=len(case_results),
+        passed=passed,
+        failed=failed,
+        skipped=skipped,
+        metrics=aggregate_metrics(case_results),
+        errors=errors,
+    )
+    output = {
+        "schema_version": 1,
+        "suite": SUITE,
+        "service": SERVICE,
+        "summary": summary,
+        "cases_path": str(cases_path),
+        "repeat": args.repeat,
+        "warmup": args.warmup,
+        "measured_at": datetime.now(timezone.utc).isoformat(),
+        "runtime_profile": runtime_profile,
+        "performance_targets": case_payload.get("performance_targets", {}),
+        "case_results": case_results,
+    }
+    write_report(out_path, output)
+
+    for result in case_results:
+        if result.get("status") == "skipped":
+            print(f"[SKIP] {result['id']} {result.get('reason')}")
+    if failed:
+        for error in errors:
+            print(f"[FAIL] {error}")
+        print(json.dumps(summary, ensure_ascii=False))
+        print(f"report={out_path}")
+        return 1
+
+    print("[OK] timetable OCR performance baseline")
+    print(json.dumps(summary, ensure_ascii=False))
+    print(f"report={out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/regression/timetable/measure_timetable_ocr_baseline.py
+++ b/tests/regression/timetable/measure_timetable_ocr_baseline.py
@@ -138,7 +138,9 @@ def extract_run_metrics(report: Dict[str, Any]) -> Dict[str, Any]:
         "y_line_count": int(grid.get("y_line_count", 0) or 0),
         "accepted_cell_count": int(ocr.get("accepted_cells", 0) or 0),
         "total_cell_count": int(ocr.get("total_cells", 0) or 0),
+        "ocr_task_cell_count": int(ocr.get("ocr_task_cells", 0) or 0),
         "text_cell_count": int(ocr.get("text_cells", 0) or 0),
+        "skipped_empty_cell_count": int(ocr.get("skipped_empty_cells", 0) or 0),
         "fallback_cell_count": int(ocr.get("fallback_cells", 0) or 0),
     }
 
@@ -165,7 +167,9 @@ def summarize_runs(runs: List[Dict[str, Any]]) -> Dict[str, Any]:
         "y_line_count": first_run.get("y_line_count"),
         "accepted_cell_count": first_run.get("accepted_cell_count"),
         "total_cell_count": first_run.get("total_cell_count"),
+        "ocr_task_cell_count": first_run.get("ocr_task_cell_count"),
         "text_cell_count": first_run.get("text_cell_count"),
+        "skipped_empty_cell_count": first_run.get("skipped_empty_cell_count"),
         "fallback_cell_count": first_run.get("fallback_cell_count"),
     }
 
@@ -280,6 +284,9 @@ def aggregate_metrics(case_results: List[Dict[str, Any]]) -> Dict[str, Any]:
         "average_ocr_duration_ms": average_int(ocr_durations),
         "max_ocr_duration_ms": max(ocr_durations) if ocr_durations else None,
         "total_extracted_schedule_count": sum(int(run.get("schedule_count", 0)) for run in runs),
+        "total_cell_count": sum(int(run.get("total_cell_count", 0)) for run in runs),
+        "ocr_task_cell_count": sum(int(run.get("ocr_task_cell_count", 0)) for run in runs),
+        "skipped_empty_cell_count": sum(int(run.get("skipped_empty_cell_count", 0)) for run in runs),
         "failure_count": len(failure_reasons),
         "failure_reasons": sorted(set(failure_reasons)),
         "skipped_case_count": sum(1 for result in case_results if result.get("status") == "skipped"),

--- a/tests/regression/timetable/timetable_ocr_performance_cases.json
+++ b/tests/regression/timetable/timetable_ocr_performance_cases.json
@@ -1,0 +1,39 @@
+{
+  "suite": "timetable_ocr_performance_baseline",
+  "cases": [
+    {
+      "id": "image_1",
+      "path": "data/image/1.png"
+    },
+    {
+      "id": "image_2",
+      "path": "data/image/2.png"
+    },
+    {
+      "id": "image_3",
+      "path": "data/image/3.jpeg"
+    },
+    {
+      "id": "image_4",
+      "path": "data/image/4.png"
+    },
+    {
+      "id": "capture_heetae",
+      "path": "data/image/capture_heetae.png"
+    },
+    {
+      "id": "capture_jeseung",
+      "path": "data/image/capture_jeseung.png"
+    }
+  ],
+  "performance_targets": {
+    "max_total_duration_regression_ratio": 1.1,
+    "average_total_duration_regression_ratio": 1.1,
+    "p95_total_duration_regression_ratio": 1.1,
+    "average_ocr_duration_regression_ratio": 1.0,
+    "notes": [
+      "This file defines the first local/OCI sample set for measuring the current timetable OCR runtime baseline.",
+      "Targets are documented for follow-up comparison runs and are not enforced by this baseline writer."
+    ]
+  }
+}


### PR DESCRIPTION
## 관련 이슈

Closes #138 

## 🎯 배경

- OCI CPU 환경에서 시간표 이미지 OCR 처리 시간이 길어지는 문제가 있어 운영 경로를 더 무겁게 만들지 않는 개선이 필요했습니다.
- 전체 셀에 OCR을 수행하기 전에 OpenCV 기반 텍스트 존재 여부를 먼저 판단해 빈 셀 OCR을 줄이고자 했습니다.
- psm11 fallback은 정확도 보완용으로만 제한적으로 사용해 timeout/queue 영향이 커지지 않도록 했습니다.

## 🔍 주요 내용

- 시간표 셀에 OpenCV text-presence detector를 적용해 빈 셀은 psm6 OCR 전에 스킵하도록 개선했습니다.
- psm6 실패 후보 중 텍스트 흔적이 있는 셀만 psm11 fallback 후보로 올리고, 런타임 fallback은 최대 5개 셀로 제한했습니다.
- OCR 진단/운영 로그에 OCR 대상 셀 수, 빈 셀 스킵 수, fallback 후보/시도 수를 추가했습니다.
- production/oci-constrained 기준선 측정 스크립트와 empty-cell skip 분석 스크립트를 추가했습니다.
- 실제 시간표 샘플 케이스 목록을 분리해 반복 측정과 OCI 비교가 가능하도록 정리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 요약(1~3줄)
  - 시간표 OCR의 OCI CPU 제한 환경 성능을 개선하기 위해 빈 셀을 먼저 걸러 OCR 작업량을 줄이고, 런타임 폴백을 보수적으로 제한했습니다.
  - 기준선 측정/빈 셀 스킵 분석 스크립트와 진단 지표를 추가해 성능 비교와 운영 관측성을 강화했습니다.

## 주요 변경점(불릿 3~7개)
  - OpenCV 기반 텍스트 존재 판정으로 빈 셀은 OCR 전에 스킵하도록 개선했습니다.
  - psm6 실패 셀 중 텍스트 흔적이 있는 경우에만 psm11 폴백 후보로 올리고, 런타임 폴백은 최대 5개로 제한했습니다.
  - OCR 런타임 로그에 대상 셀 수, 스킵된 빈 셀 수, 폴백 후보/시도 수를 추가했습니다.
  - 시간표 OCR 기준선 측정 스크립트를 추가해 `production` / `oci-constrained` 프로필 비교가 가능해졌습니다.
  - 빈 셀 스킵 분석용 dry-run 스크립트와 성능 케이스 JSON을 추가했습니다.
  - 진단 평가에 `skipped_empty_cell_count` 지표를 포함하고, 로깅의 fallback 판정 기준을 정리했습니다.
  - 회귀 테스트 README에 새 측정/분석 커맨드와 리포트 동작을 문서화했습니다.

## 주의/리스크(있으면 1~3개)
  - 텍스트 존재 판정 임계값이 너무 보수적이면 일부 셀이 불필요하게 OCR 대상에서 제외될 수 있습니다.
  - 폴백 상한이 있어 극단적인 실패 케이스에서는 복구율이 낮아질 수 있습니다.

## 다음 액션(있으면 1~3개)
  - `production`과 `oci-constrained` 기준선 리포트를 비교해 실제 개선폭을 확인하면 좋습니다.
  - 빈 셀 스킵 분석 결과로 OpenCV 텍스트 검출 임계값을 더 다듬으면 좋습니다.
  - 진단 테스트에서 `skipped_empty_cell_count`와 폴백 통계를 함께 확인하면 좋습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->