### PR TITLE
feat: gate text filter strong rules with feature flag

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -39,6 +39,7 @@ class Settings:
     json_only_mode: bool
     chatbot_profanity_filter_enabled: bool
     chatbot_log_db_required: bool
+    text_filter_strong_rule_override: bool
     text_filter_api_url: str | None
     text_filter_api_timeout: float
     root_base_path: str | None
@@ -101,6 +102,7 @@ def get_settings() -> Settings:
         json_only_mode=os.getenv("JSON_ONLY_MODE", "0").strip() == "1",
         chatbot_profanity_filter_enabled=os.getenv("CHATBOT_PROFANITY_FILTER_ENABLED", "0").strip() == "1",
         chatbot_log_db_required=os.getenv("CHATBOT_LOG_DB_REQUIRED", "0").strip() == "1",
+        text_filter_strong_rule_override=os.getenv("TEXT_FILTER_STRONG_RULE_OVERRIDE", "0").strip() == "1",
         text_filter_api_url=os.getenv("TEXT_FILTER_API_URL"),
         text_filter_api_timeout=_get_float_env("TEXT_FILTER_API_TIMEOUT", 10.0),
         root_base_path=os.getenv("ROOT_BASE_PATH"),

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -106,6 +106,7 @@ User Query → Greeting/Intent Detection → Hybrid Search (BM25 + embeddings)
 | `OSS_BASE_URL`                            | Ollama server URL (`http://localhost:11434/v1`) |
 | `OSS_MODEL`                               | LLM model name (`gpt-oss:20b`)                  |
 | `CHATBOT_LOG_DB_REQUIRED`                 | Fail chatbot startup if log DB is unavailable (`0` by default) |
+| `TEXT_FILTER_STRONG_RULE_OVERRIDE`        | Apply strong text-filter rule matches to `has_profanity` (`0` by default) |
 | `SECRET_KEY` / `ALGORITHM`                | JWT auth (HS512)                                |
 | `DB_NAME/USER/PASSWORD`                   | PostgreSQL credentials                          |
 | `DATA_JSON`                               | School info corpus path                         |

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -15,6 +15,7 @@ python tests/regression/chatbot/check_chatbot_tool_routing.py
 python tests/regression/timetable/check_timetable_ocr_diagnostics.py
 python tests/regression/text_filtering/check_text_filter_quality_report.py
 python tests/regression/text_filtering/check_text_filter_normalization.py
+python tests/regression/text_filtering/check_text_filter_word_matcher.py
 ```
 
 ## Evaluation Metrics Policy
@@ -59,6 +60,7 @@ python tests/regression/text_filtering/check_text_filter_normalization.py
 `tests/regression/text_filtering/check_text_filter_quality_report.py`는 `tests/regression/text_filtering/text_filter_quality_cases.json`의 케이스를 읽어 기존 텍스트 필터 판정 로직을 평가합니다.
 현재 케이스 파일의 1차 목적은 단어 단위 shadow 탐지 작업 전에 운영 True/False 및 `has_profanity` 판정 기준선을 고정하는 것입니다.
 `tests/regression/text_filtering/check_text_filter_normalization.py`는 운영 판정과 연결하지 않은 정규화 후보 생성 helper만 검증합니다.
+`tests/regression/text_filtering/check_text_filter_word_matcher.py`는 정규화 후보 기반 단어 단위 match 근거 생성을 검증하며, 운영 API 판정에는 연결하지 않습니다.
 
 - `false_positive_count`: 정상 문장을 비속어로 판정한 케이스 수
 - `false_negative_count`: 비속어 문장을 정상으로 판정한 케이스 수

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -67,6 +67,8 @@ python tests/regression/text_filtering/check_text_filter_word_matcher.py
 - `pass_rate`: 전체 golden case 기대값과 실제 결과가 일치한 비율
 - `ml_filter_pass_rate`: 현재 ML 기반 판정 경로 기준 통과율
 - `rule_endpoint_pass_rate`: 현재 `/text_filter_rule` API 계약의 공유 판정 경로 기준 통과율
+- `shadow_match_count`: 운영 판정에 연결하지 않은 단어 단위 detector match 수
+- `shadow_detected_false_negative_count`: 기존 모델이 놓친 비속어 케이스 중 shadow detector가 match 근거를 만든 수
 
 이 스크립트는 `analyze_text_labels()`만 호출하므로 테스트 문장을 `data/bad_text_sample.txt`에 append하지 않습니다. 모델 파일 또는 의존성이 없는 환경에서는 실패 대신 `status: "skipped"` 리포트를 기본 경로에 기록합니다.
 기본 실행은 품질 리포트를 기록하고 종료 코드는 0으로 유지합니다. 품질 실패를 게이트로 쓰려면 `--strict`를 함께 사용합니다.

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -14,6 +14,7 @@ python tests/regression/chatbot/evaluate_rag_retrieval.py
 python tests/regression/chatbot/check_chatbot_tool_routing.py
 python tests/regression/timetable/check_timetable_ocr_diagnostics.py
 python tests/regression/text_filtering/check_text_filter_quality_report.py
+python tests/regression/text_filtering/check_text_filter_normalization.py
 ```
 
 ## Evaluation Metrics Policy
@@ -57,6 +58,7 @@ python tests/regression/text_filtering/check_text_filter_quality_report.py
 
 `tests/regression/text_filtering/check_text_filter_quality_report.py`는 `tests/regression/text_filtering/text_filter_quality_cases.json`의 케이스를 읽어 기존 텍스트 필터 판정 로직을 평가합니다.
 현재 케이스 파일의 1차 목적은 단어 단위 shadow 탐지 작업 전에 운영 True/False 및 `has_profanity` 판정 기준선을 고정하는 것입니다.
+`tests/regression/text_filtering/check_text_filter_normalization.py`는 운영 판정과 연결하지 않은 정규화 후보 생성 helper만 검증합니다.
 
 - `false_positive_count`: 정상 문장을 비속어로 판정한 케이스 수
 - `false_negative_count`: 비속어 문장을 정상으로 판정한 케이스 수

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -63,6 +63,7 @@ python tests/regression/text_filtering/check_text_filter_match_details_response.
 `tests/regression/text_filtering/check_text_filter_normalization.py`는 운영 판정과 연결하지 않은 정규화 후보 생성 helper만 검증합니다.
 `tests/regression/text_filtering/check_text_filter_word_matcher.py`는 정규화 후보 기반 단어 단위 match 근거 생성을 검증하며, 운영 API 판정에는 연결하지 않습니다.
 `tests/regression/text_filtering/check_text_filter_match_details_response.py`는 필드별 응답에 `matches`가 추가되어도 기존 `has_profanity`와 `results` 계약이 유지되는지 검증합니다.
+`TEXT_FILTER_STRONG_RULE_OVERRIDE=1`이면 strong rule candidate match를 재학습 전 임시 보호막으로 `has_profanity` 판정에 반영합니다. 기본값은 `0`입니다.
 
 - `false_positive_count`: 정상 문장을 비속어로 판정한 케이스 수
 - `false_negative_count`: 비속어 문장을 정상으로 판정한 케이스 수

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -69,6 +69,8 @@ python tests/regression/text_filtering/check_text_filter_word_matcher.py
 - `rule_endpoint_pass_rate`: 현재 `/text_filter_rule` API 계약의 공유 판정 경로 기준 통과율
 - `shadow_match_count`: 운영 판정에 연결하지 않은 단어 단위 detector match 수
 - `shadow_detected_false_negative_count`: 기존 모델이 놓친 비속어 케이스 중 shadow detector가 match 근거를 만든 수
+- `shadow_strong_rule_candidate_match_count`: feature flag 기반 운영 반영 후보로 분리된 강한 규칙 match 수
+- `shadow_strong_rule_detected_false_negative_count`: 기존 모델이 놓친 케이스 중 강한 규칙 후보가 match 근거를 만든 수
 
 이 스크립트는 `analyze_text_labels()`만 호출하므로 테스트 문장을 `data/bad_text_sample.txt`에 append하지 않습니다. 모델 파일 또는 의존성이 없는 환경에서는 실패 대신 `status: "skipped"` 리포트를 기본 경로에 기록합니다.
 기본 실행은 품질 리포트를 기록하고 종료 코드는 0으로 유지합니다. 품질 실패를 게이트로 쓰려면 `--strict`를 함께 사용합니다.

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -56,6 +56,7 @@ python tests/regression/text_filtering/check_text_filter_quality_report.py
 ### Text Filtering Quality Metrics
 
 `tests/regression/text_filtering/check_text_filter_quality_report.py`는 `tests/regression/text_filtering/text_filter_quality_cases.json`의 케이스를 읽어 기존 텍스트 필터 판정 로직을 평가합니다.
+현재 케이스 파일의 1차 목적은 단어 단위 shadow 탐지 작업 전에 운영 True/False 및 `has_profanity` 판정 기준선을 고정하는 것입니다.
 
 - `false_positive_count`: 정상 문장을 비속어로 판정한 케이스 수
 - `false_negative_count`: 비속어 문장을 정상으로 판정한 케이스 수

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -16,6 +16,7 @@ python tests/regression/timetable/check_timetable_ocr_diagnostics.py
 python tests/regression/text_filtering/check_text_filter_quality_report.py
 python tests/regression/text_filtering/check_text_filter_normalization.py
 python tests/regression/text_filtering/check_text_filter_word_matcher.py
+python tests/regression/text_filtering/check_text_filter_match_details_response.py
 ```
 
 ## Evaluation Metrics Policy
@@ -61,6 +62,7 @@ python tests/regression/text_filtering/check_text_filter_word_matcher.py
 현재 케이스 파일의 1차 목적은 단어 단위 shadow 탐지 작업 전에 운영 True/False 및 `has_profanity` 판정 기준선을 고정하는 것입니다.
 `tests/regression/text_filtering/check_text_filter_normalization.py`는 운영 판정과 연결하지 않은 정규화 후보 생성 helper만 검증합니다.
 `tests/regression/text_filtering/check_text_filter_word_matcher.py`는 정규화 후보 기반 단어 단위 match 근거 생성을 검증하며, 운영 API 판정에는 연결하지 않습니다.
+`tests/regression/text_filtering/check_text_filter_match_details_response.py`는 필드별 응답에 `matches`가 추가되어도 기존 `has_profanity`와 `results` 계약이 유지되는지 검증합니다.
 
 - `false_positive_count`: 정상 문장을 비속어로 판정한 케이스 수
 - `false_negative_count`: 비속어 문장을 정상으로 판정한 케이스 수

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -64,6 +64,7 @@ python tests/regression/text_filtering/check_text_filter_match_details_response.
 `tests/regression/text_filtering/check_text_filter_word_matcher.py`는 정규화 후보 기반 단어 단위 match 근거 생성을 검증하며, 운영 API 판정에는 연결하지 않습니다.
 `tests/regression/text_filtering/check_text_filter_match_details_response.py`는 필드별 응답에 `matches`가 추가되어도 기존 `has_profanity`와 `results` 계약이 유지되는지 검증합니다.
 `TEXT_FILTER_STRONG_RULE_OVERRIDE=1`이면 strong rule candidate match를 재학습 전 임시 보호막으로 `has_profanity` 판정에 반영합니다. 기본값은 `0`입니다.
+품질 리포트의 pass/fail은 `analyze_text_labels()`의 기존 모델 라벨 기준입니다. Strong rule override 효과는 shadow 지표와 `check_text_filter_match_details_response.py`에서 확인합니다.
 
 - `false_positive_count`: 정상 문장을 비속어로 판정한 케이스 수
 - `false_negative_count`: 비속어 문장을 정상으로 판정한 케이스 수

--- a/tests/regression/text_filtering/check_text_filter_match_details_response.py
+++ b/tests/regression/text_filtering/check_text_filter_match_details_response.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+def main() -> int:
+    try:
+        from text_filtering import service as text_filter_service
+    except ModuleNotFoundError as exc:
+        print(f"[SKIP] text filtering dependency is missing: {exc.name}")
+        return 0
+
+    original_predict = text_filter_service.predict
+    original_contains_english_profanity = text_filter_service.contains_english_profanity
+
+    try:
+        text_filter_service.predict = lambda text: (0, "정상")
+        text_filter_service.contains_english_profanity = lambda text: False
+        result = text_filter_service.analyze_field("content", "ㅅ1발처럼 숫자를 섞은 표현", should_log=False)
+    finally:
+        text_filter_service.predict = original_predict
+        text_filter_service.contains_english_profanity = original_contains_english_profanity
+
+    failures: list[str] = []
+    if result.get("has_profanity") is not False:
+        failures.append("has_profanity_changed_by_match_details")
+    if result.get("results") != [{"sentence": "ㅅ1발처럼 숫자를 섞은 표현", "label": "정상"}]:
+        failures.append(f"results_contract_changed:{result.get('results')}")
+
+    matches = result.get("matches")
+    if not isinstance(matches, list) or not matches:
+        failures.append("missing_matches")
+    else:
+        first_match = matches[0]
+        if first_match.get("pattern_id") != "korean_number_sibal":
+            failures.append(f"unexpected_pattern:{first_match.get('pattern_id')}")
+        if first_match.get("sentence_index") != 1:
+            failures.append(f"unexpected_sentence_index:{first_match.get('sentence_index')}")
+        if first_match.get("strong_rule_candidate") is not True:
+            failures.append("expected_strong_rule_candidate")
+
+    if failures:
+        for failure in failures:
+            print(f"[FAIL] {failure}")
+        return 1
+
+    print("[OK] text filter match details response is backward compatible")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/regression/text_filtering/check_text_filter_match_details_response.py
+++ b/tests/regression/text_filtering/check_text_filter_match_details_response.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 import sys
 from pathlib import Path
 
@@ -9,6 +10,7 @@ if str(ROOT_DIR) not in sys.path:
 
 def main() -> int:
     try:
+        from core.settings import get_settings
         from text_filtering import service as text_filter_service
     except ModuleNotFoundError as exc:
         print(f"[SKIP] text filtering dependency is missing: {exc.name}")
@@ -20,10 +22,18 @@ def main() -> int:
     try:
         text_filter_service.predict = lambda text: (0, "정상")
         text_filter_service.contains_english_profanity = lambda text: False
+        os.environ.pop("TEXT_FILTER_STRONG_RULE_OVERRIDE", None)
+        get_settings.cache_clear()
         result = text_filter_service.analyze_field("content", "ㅅ1발처럼 숫자를 섞은 표현", should_log=False)
+
+        os.environ["TEXT_FILTER_STRONG_RULE_OVERRIDE"] = "1"
+        get_settings.cache_clear()
+        override_result = text_filter_service.analyze_field("content", "ㅅ1발처럼 숫자를 섞은 표현", should_log=False)
     finally:
         text_filter_service.predict = original_predict
         text_filter_service.contains_english_profanity = original_contains_english_profanity
+        os.environ.pop("TEXT_FILTER_STRONG_RULE_OVERRIDE", None)
+        get_settings.cache_clear()
 
     failures: list[str] = []
     if result.get("has_profanity") is not False:
@@ -42,6 +52,18 @@ def main() -> int:
             failures.append(f"unexpected_sentence_index:{first_match.get('sentence_index')}")
         if first_match.get("strong_rule_candidate") is not True:
             failures.append("expected_strong_rule_candidate")
+
+    override = result.get("strong_rule_override")
+    if override != {"enabled": False, "applied": False, "match_count": 1}:
+        failures.append(f"unexpected_default_override_state:{override}")
+
+    override_state = override_result.get("strong_rule_override")
+    if override_result.get("has_profanity") is not True:
+        failures.append("strong_rule_override_did_not_raise_has_profanity")
+    if override_result.get("results") != [{"sentence": "ㅅ1발처럼 숫자를 섞은 표현", "label": "정상"}]:
+        failures.append(f"override_changed_model_results:{override_result.get('results')}")
+    if override_state != {"enabled": True, "applied": True, "match_count": 1}:
+        failures.append(f"unexpected_enabled_override_state:{override_state}")
 
     if failures:
         for failure in failures:

--- a/tests/regression/text_filtering/check_text_filter_normalization.py
+++ b/tests/regression/text_filtering/check_text_filter_normalization.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from text_filtering.normalization import normalize_text_variants
+
+
+CASES = [
+    {
+        "id": "spacing_variant",
+        "text": "시 발",
+        "expected": ("compact", "시발"),
+    },
+    {
+        "id": "special_character_variant",
+        "text": "씨@발",
+        "expected": ("symbol_removed_compact", "씨발"),
+    },
+    {
+        "id": "repeated_character_variant",
+        "text": "씨이발",
+        "expected": ("repeated_collapsed_compact", "씨발"),
+    },
+    {
+        "id": "english_number_variant",
+        "text": "sh1t",
+        "expected": ("latin_number_mapped_compact", "shit"),
+    },
+    {
+        "id": "romanized_korean_variant",
+        "text": "SI BAL",
+        "expected": ("compact", "sibal"),
+    },
+    {
+        "id": "korean_number_variant",
+        "text": "ㅅ1발",
+        "expected": ("korean_number_mapped_compact", "ㅅㅣ발"),
+    },
+    {
+        "id": "false_positive_guard",
+        "text": "시발점",
+        "expected": ("original", "시발점"),
+    },
+]
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for case in CASES:
+        variants = normalize_text_variants(case["text"])
+        key, expected_value = case["expected"]
+        actual_value = variants.get(key)
+        if actual_value != expected_value:
+            failures.append(f"{case['id']}:{key}:expected={expected_value}:actual={actual_value}")
+
+    if failures:
+        for failure in failures:
+            print(f"[FAIL] {failure}")
+        return 1
+
+    print(f"[OK] text filter normalization cases passed: {len(CASES)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/regression/text_filtering/check_text_filter_quality_report.py
+++ b/tests/regression/text_filtering/check_text_filter_quality_report.py
@@ -194,7 +194,12 @@ def aggregate_shadow_metrics(case_results: list[dict[str, Any]]) -> dict[str, An
     shadow_detected_false_negative_count = 0
     shadow_false_positive_candidate_count = 0
     shadow_true_positive_candidate_count = 0
+    shadow_strong_rule_candidate_match_count = 0
+    shadow_strong_rule_candidate_case_count = 0
+    shadow_strong_rule_detected_false_negative_count = 0
+    shadow_strong_rule_false_positive_candidate_count = 0
     pattern_counts: dict[str, int] = {}
+    strong_rule_pattern_counts: dict[str, int] = {}
     by_category: dict[str, dict[str, Any]] = {}
 
     for result in case_results:
@@ -205,6 +210,9 @@ def aggregate_shadow_metrics(case_results: list[dict[str, Any]]) -> dict[str, An
         matches = shadow.get("matches", []) if isinstance(shadow, dict) else []
         match_count = len(matches)
         has_match = match_count > 0
+        strong_matches = [match for match in matches if match.get("strong_rule_candidate") is True]
+        strong_match_count = len(strong_matches)
+        has_strong_match = strong_match_count > 0
 
         bucket = by_category.setdefault(
             category,
@@ -214,6 +222,9 @@ def aggregate_shadow_metrics(case_results: list[dict[str, Any]]) -> dict[str, An
                 "shadow_unmatched": 0,
                 "shadow_false_positive_candidates": 0,
                 "shadow_detected_false_negatives": 0,
+                "shadow_strong_rule_matched": 0,
+                "shadow_strong_rule_false_positive_candidates": 0,
+                "shadow_strong_rule_detected_false_negatives": 0,
             },
         )
         bucket["total"] += 1
@@ -227,6 +238,13 @@ def aggregate_shadow_metrics(case_results: list[dict[str, Any]]) -> dict[str, An
         for match in matches:
             pattern_id = str(match.get("pattern_id", "") or "unknown")
             pattern_counts[pattern_id] = pattern_counts.get(pattern_id, 0) + 1
+            if match.get("strong_rule_candidate") is True:
+                shadow_strong_rule_candidate_match_count += 1
+                strong_rule_pattern_counts[pattern_id] = strong_rule_pattern_counts.get(pattern_id, 0) + 1
+
+        if has_strong_match:
+            shadow_strong_rule_candidate_case_count += 1
+            bucket["shadow_strong_rule_matched"] += 1
 
         if expected_has_profanity and has_match:
             shadow_true_positive_candidate_count += 1
@@ -236,9 +254,18 @@ def aggregate_shadow_metrics(case_results: list[dict[str, Any]]) -> dict[str, An
         if expected_has_profanity and not actual_has_profanity and has_match:
             shadow_detected_false_negative_count += 1
             bucket["shadow_detected_false_negatives"] += 1
+        if not expected_has_profanity and has_strong_match:
+            shadow_strong_rule_false_positive_candidate_count += 1
+            bucket["shadow_strong_rule_false_positive_candidates"] += 1
+        if expected_has_profanity and not actual_has_profanity and has_strong_match:
+            shadow_strong_rule_detected_false_negative_count += 1
+            bucket["shadow_strong_rule_detected_false_negatives"] += 1
 
     for bucket in by_category.values():
         bucket["shadow_match_rate"] = round(bucket["shadow_matched"] / bucket["total"], 4) if bucket["total"] else 0.0
+        bucket["shadow_strong_rule_match_rate"] = (
+            round(bucket["shadow_strong_rule_matched"] / bucket["total"], 4) if bucket["total"] else 0.0
+        )
 
     return {
         "shadow_match_count": shadow_match_count,
@@ -248,6 +275,11 @@ def aggregate_shadow_metrics(case_results: list[dict[str, Any]]) -> dict[str, An
         "shadow_false_positive_candidate_count": shadow_false_positive_candidate_count,
         "shadow_detected_false_negative_count": shadow_detected_false_negative_count,
         "shadow_pattern_counts": pattern_counts,
+        "shadow_strong_rule_candidate_match_count": shadow_strong_rule_candidate_match_count,
+        "shadow_strong_rule_candidate_case_count": shadow_strong_rule_candidate_case_count,
+        "shadow_strong_rule_detected_false_negative_count": shadow_strong_rule_detected_false_negative_count,
+        "shadow_strong_rule_false_positive_candidate_count": shadow_strong_rule_false_positive_candidate_count,
+        "shadow_strong_rule_pattern_counts": strong_rule_pattern_counts,
         "shadow_by_category": by_category,
     }
 

--- a/tests/regression/text_filtering/check_text_filter_quality_report.py
+++ b/tests/regression/text_filtering/check_text_filter_quality_report.py
@@ -13,6 +13,7 @@ DEFAULT_CASES_PATH = ROOT_DIR / "tests" / "regression" / "text_filtering" / "tex
 DEFAULT_REPORT_PATH = ROOT_DIR / "tests" / "reports" / "text_filtering" / "text_filter_quality_report.json"
 SUITE = "text_filter_quality"
 SERVICE = "text_filtering"
+BASELINE_PHASE = "1"
 
 
 def load_cases(path: Path) -> list[dict[str, Any]]:
@@ -21,6 +22,12 @@ def load_cases(path: Path) -> list[dict[str, Any]]:
     if not isinstance(cases, list) or not cases:
         raise ValueError(f"no text filtering cases found in {path}")
     return cases
+
+
+def load_case_metadata(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    metadata = payload.get("metadata", {})
+    return metadata if isinstance(metadata, dict) else {}
 
 
 def validate_cases(cases: list[dict[str, Any]]) -> list[str]:
@@ -52,6 +59,14 @@ def validate_cases(cases: list[dict[str, Any]]) -> list[str]:
     return errors
 
 
+def count_cases_by_category(cases: list[dict[str, Any]]) -> dict[str, int]:
+    by_category: dict[str, int] = {}
+    for case in cases:
+        category = str(case.get("category", "") or "uncategorized")
+        by_category[category] = by_category.get(category, 0) + 1
+    return by_category
+
+
 def write_report(out_path: Path, output: dict[str, Any]) -> None:
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(output, ensure_ascii=False, indent=2), encoding="utf-8")
@@ -81,6 +96,7 @@ def make_summary(
 
 
 def write_skipped_report(out_path: Path, reason: str, cases_path: Path) -> None:
+    metadata = load_case_metadata(cases_path)
     summary = make_summary(
         status="skipped",
         total=0,
@@ -94,6 +110,11 @@ def write_skipped_report(out_path: Path, reason: str, cases_path: Path) -> None:
         "schema_version": 1,
         "suite": SUITE,
         "service": SERVICE,
+        "baseline": {
+            "phase": BASELINE_PHASE,
+            "report_only": True,
+            "case_metadata": metadata,
+        },
         "summary": summary,
         "cases_path": str(cases_path),
         "skipped": {
@@ -202,8 +223,10 @@ def main() -> int:
 
     cases_path = Path(args.cases)
     out_path = Path(args.out)
+    case_metadata = load_case_metadata(cases_path)
     cases = load_cases(cases_path)
     validation_errors = validate_cases(cases)
+    case_category_counts = count_cases_by_category(cases)
 
     if validation_errors:
         failed_case_ids = {
@@ -223,6 +246,12 @@ def main() -> int:
             "schema_version": 1,
             "suite": SUITE,
             "service": SERVICE,
+            "baseline": {
+                "phase": BASELINE_PHASE,
+                "report_only": True,
+                "case_metadata": case_metadata,
+                "case_category_counts": case_category_counts,
+            },
             "summary": summary,
             "cases_path": str(cases_path),
             "case_results": [],
@@ -241,13 +270,24 @@ def main() -> int:
             passed=len(cases),
             failed=0,
             skipped=0,
-            metrics={"validated_case_count": len(cases)},
+            metrics={
+                "validated_case_count": len(cases),
+                "case_category_counts": case_category_counts,
+                "baseline_phase": BASELINE_PHASE,
+                "report_only": True,
+            },
             errors=[],
         )
         output = {
             "schema_version": 1,
             "suite": SUITE,
             "service": SERVICE,
+            "baseline": {
+                "phase": BASELINE_PHASE,
+                "report_only": True,
+                "case_metadata": case_metadata,
+                "case_category_counts": case_category_counts,
+            },
             "summary": summary,
             "cases_path": str(cases_path),
             "case_results": [],
@@ -273,13 +313,24 @@ def main() -> int:
         passed=passed,
         failed=failed,
         skipped=0,
-        metrics=aggregate_metrics(case_results),
+        metrics={
+            **aggregate_metrics(case_results),
+            "case_category_counts": case_category_counts,
+            "baseline_phase": BASELINE_PHASE,
+            "report_only": True,
+        },
         errors=errors,
     )
     output = {
         "schema_version": 1,
         "suite": SUITE,
         "service": SERVICE,
+        "baseline": {
+            "phase": BASELINE_PHASE,
+            "report_only": True,
+            "case_metadata": case_metadata,
+            "case_category_counts": case_category_counts,
+        },
         "summary": summary,
         "cases_path": str(cases_path),
         "case_results": case_results,

--- a/tests/regression/text_filtering/check_text_filter_quality_report.py
+++ b/tests/regression/text_filtering/check_text_filter_quality_report.py
@@ -150,10 +150,13 @@ def load_text_filter_service(out_path: Path, cases_path: Path):
 
 
 def evaluate_case(case: dict[str, Any], text_filter_service) -> dict[str, Any]:
+    from text_filtering.word_matcher import detect_bad_word_match_dicts
+
     text = str(case.get("text", "") or "")
     expected_has_profanity = bool(case.get("expected", {}).get("has_profanity"))
     labels = text_filter_service.analyze_text_labels(text)
     actual_has_profanity = any(label == "비속어" for label in labels)
+    shadow_matches = detect_bad_word_match_dicts(text)
     passed = actual_has_profanity == expected_has_profanity
 
     errors: list[str] = []
@@ -174,8 +177,78 @@ def evaluate_case(case: dict[str, Any], text_filter_service) -> dict[str, Any]:
             "has_profanity": actual_has_profanity,
             "labels": labels,
         },
+        "shadow": {
+            "has_match": bool(shadow_matches),
+            "match_count": len(shadow_matches),
+            "matches": shadow_matches,
+        },
         "status": "passed" if passed else "failed",
         "errors": errors,
+    }
+
+
+def aggregate_shadow_metrics(case_results: list[dict[str, Any]]) -> dict[str, Any]:
+    total = len(case_results)
+    shadow_matched_case_count = 0
+    shadow_match_count = 0
+    shadow_detected_false_negative_count = 0
+    shadow_false_positive_candidate_count = 0
+    shadow_true_positive_candidate_count = 0
+    pattern_counts: dict[str, int] = {}
+    by_category: dict[str, dict[str, Any]] = {}
+
+    for result in case_results:
+        category = str(result.get("category", "") or "uncategorized")
+        expected_has_profanity = bool(result.get("expected", {}).get("has_profanity"))
+        actual_has_profanity = bool(result.get("actual", {}).get("has_profanity"))
+        shadow = result.get("shadow", {})
+        matches = shadow.get("matches", []) if isinstance(shadow, dict) else []
+        match_count = len(matches)
+        has_match = match_count > 0
+
+        bucket = by_category.setdefault(
+            category,
+            {
+                "total": 0,
+                "shadow_matched": 0,
+                "shadow_unmatched": 0,
+                "shadow_false_positive_candidates": 0,
+                "shadow_detected_false_negatives": 0,
+            },
+        )
+        bucket["total"] += 1
+        if has_match:
+            shadow_matched_case_count += 1
+            bucket["shadow_matched"] += 1
+        else:
+            bucket["shadow_unmatched"] += 1
+
+        shadow_match_count += match_count
+        for match in matches:
+            pattern_id = str(match.get("pattern_id", "") or "unknown")
+            pattern_counts[pattern_id] = pattern_counts.get(pattern_id, 0) + 1
+
+        if expected_has_profanity and has_match:
+            shadow_true_positive_candidate_count += 1
+        if not expected_has_profanity and has_match:
+            shadow_false_positive_candidate_count += 1
+            bucket["shadow_false_positive_candidates"] += 1
+        if expected_has_profanity and not actual_has_profanity and has_match:
+            shadow_detected_false_negative_count += 1
+            bucket["shadow_detected_false_negatives"] += 1
+
+    for bucket in by_category.values():
+        bucket["shadow_match_rate"] = round(bucket["shadow_matched"] / bucket["total"], 4) if bucket["total"] else 0.0
+
+    return {
+        "shadow_match_count": shadow_match_count,
+        "shadow_matched_case_count": shadow_matched_case_count,
+        "shadow_match_rate": round(shadow_matched_case_count / total, 4) if total else 0.0,
+        "shadow_true_positive_candidate_count": shadow_true_positive_candidate_count,
+        "shadow_false_positive_candidate_count": shadow_false_positive_candidate_count,
+        "shadow_detected_false_negative_count": shadow_detected_false_negative_count,
+        "shadow_pattern_counts": pattern_counts,
+        "shadow_by_category": by_category,
     }
 
 
@@ -210,6 +283,7 @@ def aggregate_metrics(case_results: list[dict[str, Any]]) -> dict[str, Any]:
         "rule_filter_pass_rate": None,
         "rule_endpoint_pass_rate": pass_rate,
         "by_category": by_category,
+        **aggregate_shadow_metrics(case_results),
     }
 
 
@@ -337,6 +411,7 @@ def main() -> int:
         "notes": [
             "This report calls analyze_text_labels() only, so test cases are not appended to data/bad_text_sample.txt.",
             "rule_endpoint_pass_rate is reported for the current API contract, which uses the shared ML-backed analyzer.",
+            "shadow matches are report-only word-level detector results and do not affect pass/fail status.",
         ],
     }
     write_report(out_path, output)

--- a/tests/regression/text_filtering/check_text_filter_word_matcher.py
+++ b/tests/regression/text_filtering/check_text_filter_word_matcher.py
@@ -45,6 +45,11 @@ CASES = [
         "text": "ㅅ1발처럼 숫자를 섞은 표현",
         "expected_pattern": "korean_number_sibal",
     },
+    {
+        "id": "benign_substring_and_spacing_variant",
+        "text": "시발점은 논의고 시 발은 욕설입니다.",
+        "expected_pattern": "korean_sibal",
+    },
 ]
 
 NEGATIVE_CASES = [

--- a/tests/regression/text_filtering/check_text_filter_word_matcher.py
+++ b/tests/regression/text_filtering/check_text_filter_word_matcher.py
@@ -67,6 +67,10 @@ def main() -> int:
         pattern_ids = {match.pattern_id for match in matches}
         if case["expected_pattern"] not in pattern_ids:
             failures.append(f"{case['id']}:missing_pattern:{case['expected_pattern']}:actual={sorted(pattern_ids)}")
+            continue
+        expected_matches = [match for match in matches if match.pattern_id == case["expected_pattern"]]
+        if not any(match.strong_rule_candidate and match.rule_stage == "strong_candidate" for match in expected_matches):
+            failures.append(f"{case['id']}:expected_strong_rule_candidate:{case['expected_pattern']}")
 
     for case in NEGATIVE_CASES:
         matches = detect_bad_word_matches(case["text"])

--- a/tests/regression/text_filtering/check_text_filter_word_matcher.py
+++ b/tests/regression/text_filtering/check_text_filter_word_matcher.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from text_filtering.word_matcher import detect_bad_word_matches
+
+
+CASES = [
+    {
+        "id": "spacing_variant",
+        "text": "시 발 이라고 띄어 쓰는 표현",
+        "expected_pattern": "korean_sibal",
+    },
+    {
+        "id": "special_character_variant",
+        "text": "씨@발처럼 특수문자를 섞은 표현",
+        "expected_pattern": "korean_ssibal",
+    },
+    {
+        "id": "repeated_character_variant",
+        "text": "씨이발처럼 글자를 늘린 표현",
+        "expected_pattern": "korean_ssibal",
+    },
+    {
+        "id": "initial_consonant_variant",
+        "text": "댓글에 ㅅㅂ 같은 초성 욕설",
+        "expected_pattern": "korean_initial_s_b",
+    },
+    {
+        "id": "english_number_variant",
+        "text": "That was a sh1t response.",
+        "expected_pattern": "english_shit",
+    },
+    {
+        "id": "romanized_korean_variant",
+        "text": "댓글에 sibal 같은 로마자 욕설",
+        "expected_pattern": "romanized_sibal",
+    },
+    {
+        "id": "korean_number_variant",
+        "text": "ㅅ1발처럼 숫자를 섞은 표현",
+        "expected_pattern": "korean_number_sibal",
+    },
+]
+
+NEGATIVE_CASES = [
+    {
+        "id": "false_positive_guard",
+        "text": "이 논의의 시발점은 수업 공지 내용이었습니다.",
+    },
+    {
+        "id": "normal_english_sentence",
+        "text": "Please check the class notice before tomorrow.",
+    },
+]
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for case in CASES:
+        matches = detect_bad_word_matches(case["text"])
+        pattern_ids = {match.pattern_id for match in matches}
+        if case["expected_pattern"] not in pattern_ids:
+            failures.append(f"{case['id']}:missing_pattern:{case['expected_pattern']}:actual={sorted(pattern_ids)}")
+
+    for case in NEGATIVE_CASES:
+        matches = detect_bad_word_matches(case["text"])
+        if matches:
+            pattern_ids = sorted(match.pattern_id for match in matches)
+            failures.append(f"{case['id']}:unexpected_match:{pattern_ids}")
+
+    if failures:
+        for failure in failures:
+            print(f"[FAIL] {failure}")
+        return 1
+
+    print(f"[OK] text filter word matcher cases passed: {len(CASES) + len(NEGATIVE_CASES)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/regression/text_filtering/text_filter_quality_cases.json
+++ b/tests/regression/text_filtering/text_filter_quality_cases.json
@@ -53,6 +53,70 @@
       "expected": {
         "has_profanity": true
       }
+    },
+    {
+      "id": "korean_variant_spacing_02",
+      "category": "korean_variant_spacing",
+      "text": "씨 발처럼 일부러 띄어 쓰는 표현도 필터링 대상입니다.",
+      "expected": {
+        "has_profanity": true
+      }
+    },
+    {
+      "id": "korean_initial_consonant_01",
+      "category": "korean_initial_consonant",
+      "text": "댓글에 ㅅㅂ 같은 초성 욕설을 남기면 안 됩니다.",
+      "expected": {
+        "has_profanity": true
+      }
+    },
+    {
+      "id": "korean_special_character_01",
+      "category": "korean_special_character",
+      "text": "씨@발처럼 특수문자를 끼워 넣은 표현도 제재 대상입니다.",
+      "expected": {
+        "has_profanity": true
+      }
+    },
+    {
+      "id": "korean_repeated_character_01",
+      "category": "korean_repeated_character",
+      "text": "씨이발처럼 글자를 늘려 쓰는 표현도 비속어로 봐야 합니다.",
+      "expected": {
+        "has_profanity": true
+      }
+    },
+    {
+      "id": "english_variant_obfuscation_01",
+      "category": "english_variant_obfuscation",
+      "text": "That was a sh1t response.",
+      "expected": {
+        "has_profanity": true
+      }
+    },
+    {
+      "id": "romanized_korean_profanity_01",
+      "category": "romanized_korean_profanity",
+      "text": "댓글에 sibal 같은 로마자 욕설을 쓰면 안 됩니다.",
+      "expected": {
+        "has_profanity": true
+      }
+    },
+    {
+      "id": "korean_number_obfuscation_01",
+      "category": "korean_number_obfuscation",
+      "text": "ㅅ1발처럼 숫자를 섞은 표현도 필터링 대상입니다.",
+      "expected": {
+        "has_profanity": true
+      }
+    },
+    {
+      "id": "normal_false_positive_guard_01",
+      "category": "normal_false_positive_guard",
+      "text": "이 논의의 시발점은 수업 공지 내용이었습니다.",
+      "expected": {
+        "has_profanity": false
+      }
     }
   ]
 }

--- a/tests/regression/text_filtering/text_filter_quality_cases.json
+++ b/tests/regression/text_filtering/text_filter_quality_cases.json
@@ -1,4 +1,10 @@
 {
+  "metadata": {
+    "purpose": "baseline",
+    "phase": "1",
+    "description": "Current production text filtering behavior baseline before word-level shadow detection work.",
+    "contract": "Do not change production True/False or has_profanity behavior in this phase."
+  },
   "cases": [
     {
       "id": "clear_korean_profanity_01",
@@ -20,6 +26,14 @@
       "id": "normal_sentence_02",
       "category": "normal_sentence",
       "text": "동아리 모집 안내를 보고 친구와 함께 신청했습니다.",
+      "expected": {
+        "has_profanity": false
+      }
+    },
+    {
+      "id": "normal_english_sentence_01",
+      "category": "normal_english_sentence",
+      "text": "Please check the class notice before tomorrow.",
       "expected": {
         "has_profanity": false
       }

--- a/text_filtering/normalization.py
+++ b/text_filtering/normalization.py
@@ -1,0 +1,82 @@
+import re
+from dataclasses import asdict, dataclass
+
+
+WHITESPACE_RE = re.compile(r"\s+")
+REPEATED_CHAR_RE = re.compile(r"(.)\1{2,}")
+KOREAN_VOWEL_EXTENSION_RE = re.compile(r"([가-힣ㄱ-ㅎ])([ㅏ-ㅣ이])+(?=[가-힣ㄱ-ㅎ])")
+
+LATIN_NUMBER_MAP = str.maketrans({
+    "0": "o",
+    "1": "i",
+    "3": "e",
+    "4": "a",
+    "5": "s",
+    "7": "t",
+})
+KOREAN_NUMBER_MAP = str.maketrans({
+    "1": "ㅣ",
+})
+
+
+@dataclass(frozen=True)
+class NormalizationCandidate:
+    kind: str
+    text: str
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+def remove_symbols(text: str) -> str:
+    return "".join(char for char in text if char.isalnum() or char.isspace())
+
+
+def collapse_repeated_characters(text: str) -> str:
+    return REPEATED_CHAR_RE.sub(r"\1", text)
+
+
+def collapse_korean_vowel_extensions(text: str) -> str:
+    return KOREAN_VOWEL_EXTENSION_RE.sub(r"\1", text)
+
+
+def compact_text(text: str) -> str:
+    return WHITESPACE_RE.sub("", text)
+
+
+def normalize_text_variants(text: str) -> dict[str, str]:
+    lower = text.lower()
+    symbol_removed = remove_symbols(lower)
+    compact = compact_text(lower)
+    symbol_removed_compact = compact_text(symbol_removed)
+    latin_number_mapped = lower.translate(LATIN_NUMBER_MAP)
+    korean_number_mapped = lower.translate(KOREAN_NUMBER_MAP)
+    repeated_collapsed = collapse_korean_vowel_extensions(collapse_repeated_characters(lower))
+
+    return {
+        "original": text,
+        "lower": lower,
+        "compact": compact,
+        "symbol_removed": symbol_removed,
+        "symbol_removed_compact": symbol_removed_compact,
+        "latin_number_mapped": latin_number_mapped,
+        "latin_number_mapped_compact": compact_text(remove_symbols(latin_number_mapped)),
+        "korean_number_mapped": korean_number_mapped,
+        "korean_number_mapped_compact": compact_text(remove_symbols(korean_number_mapped)),
+        "repeated_collapsed": repeated_collapsed,
+        "repeated_collapsed_compact": compact_text(remove_symbols(repeated_collapsed)),
+    }
+
+
+def build_text_filter_normalization_candidates(text: str) -> list[NormalizationCandidate]:
+    candidates: list[NormalizationCandidate] = []
+    seen: set[tuple[str, str]] = set()
+
+    for kind, candidate_text in normalize_text_variants(text).items():
+        key = (kind, candidate_text)
+        if key in seen:
+            continue
+        seen.add(key)
+        candidates.append(NormalizationCandidate(kind=kind, text=candidate_text))
+
+    return candidates

--- a/text_filtering/normalization.py
+++ b/text_filtering/normalization.py
@@ -4,7 +4,7 @@ from dataclasses import asdict, dataclass
 
 WHITESPACE_RE = re.compile(r"\s+")
 REPEATED_CHAR_RE = re.compile(r"(.)\1{2,}")
-KOREAN_VOWEL_EXTENSION_RE = re.compile(r"([가-힣ㄱ-ㅎ])([ㅏ-ㅣ이])+(?=[가-힣ㄱ-ㅎ])")
+KOREAN_VOWEL_EXTENSION_RE = re.compile(r"([가-힣ㄱ-ㅎ])([ㅏ-ㅣ이]){2,}(?=[가-힣ㄱ-ㅎ])")
 
 LATIN_NUMBER_MAP = str.maketrans({
     "0": "o",

--- a/text_filtering/service.py
+++ b/text_filtering/service.py
@@ -15,6 +15,7 @@ from core.logging import (
     get_logger,
     runtime_log_message,
 )
+from text_filtering.word_matcher import detect_bad_word_match_dicts
 
 
 MODEL_PATH = Path("model/my_electra_finetuned")
@@ -181,6 +182,7 @@ def _sanitized_pending_log_line(sentence: str, label_num: int, sentence_index: i
 
 def analyze_field(field_name: str, text: str, should_log: bool = False) -> dict[str, Any]:
     results: list[dict[str, str]] = []
+    matches: list[dict[str, Any]] = []
     has_profanity = False
     log_lines: list[str] = []
     english_rule_override_count = 0
@@ -193,6 +195,8 @@ def analyze_field(field_name: str, text: str, should_log: bool = False) -> dict[
             english_rule_override_count += 1
 
         results.append({"sentence": sentence, "label": label_text})
+        for match in detect_bad_word_match_dicts(sentence):
+            matches.append({**match, "sentence_index": sentence_index})
         if should_log:
             log_lines.append(_sanitized_pending_log_line(sentence, label_num, sentence_index))
         if label_text == "비속어":
@@ -202,6 +206,7 @@ def analyze_field(field_name: str, text: str, should_log: bool = False) -> dict[
         "field": field_name,
         "has_profanity": has_profanity,
         "results": results,
+        "matches": matches,
         "log_lines": log_lines,
         "english_rule_override_count": english_rule_override_count,
     }

--- a/text_filtering/service.py
+++ b/text_filtering/service.py
@@ -15,6 +15,7 @@ from core.logging import (
     get_logger,
     runtime_log_message,
 )
+from core.settings import get_settings
 from text_filtering.word_matcher import detect_bad_word_match_dicts
 
 
@@ -180,12 +181,17 @@ def _sanitized_pending_log_line(sentence: str, label_num: int, sentence_index: i
     return f"text_hash={text_hash} text_length={len(sentence)} sentence_index={sentence_index}|{label_num}\n"
 
 
+def _strong_rule_matches(matches: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [match for match in matches if match.get("strong_rule_candidate") is True]
+
+
 def analyze_field(field_name: str, text: str, should_log: bool = False) -> dict[str, Any]:
     results: list[dict[str, str]] = []
     matches: list[dict[str, Any]] = []
     has_profanity = False
     log_lines: list[str] = []
     english_rule_override_count = 0
+    strong_rule_override_enabled = get_settings().text_filter_strong_rule_override
 
     for sentence_index, sentence in enumerate(split_sentences(text), start=1):
         label_num, label_text = predict(sentence)
@@ -202,11 +208,21 @@ def analyze_field(field_name: str, text: str, should_log: bool = False) -> dict[
         if label_text == "비속어":
             has_profanity = True
 
+    strong_rule_matches = _strong_rule_matches(matches)
+    strong_rule_override_applied = strong_rule_override_enabled and bool(strong_rule_matches)
+    if strong_rule_override_applied:
+        has_profanity = True
+
     return {
         "field": field_name,
         "has_profanity": has_profanity,
         "results": results,
         "matches": matches,
+        "strong_rule_override": {
+            "enabled": strong_rule_override_enabled,
+            "applied": strong_rule_override_applied,
+            "match_count": len(strong_rule_matches),
+        },
         "log_lines": log_lines,
         "english_rule_override_count": english_rule_override_count,
     }

--- a/text_filtering/word_matcher.py
+++ b/text_filtering/word_matcher.py
@@ -48,8 +48,18 @@ class WordMatch:
         return asdict(self)
 
 
-def _has_benign_korean_context(text: str, term: str) -> bool:
-    return any(benign in text for benign in BENIGN_KOREAN_SUBSTRINGS if term in benign)
+def _is_inside_benign_korean_substring(text: str, term_start: int, term_end: int) -> bool:
+    for benign in BENIGN_KOREAN_SUBSTRINGS:
+        search_from = 0
+        while True:
+            benign_start = text.find(benign, search_from)
+            if benign_start == -1:
+                break
+            benign_end = benign_start + len(benign)
+            if benign_start <= term_start and term_end <= benign_end:
+                return True
+            search_from = benign_start + 1
+    return False
 
 
 def _append_match_once(matches: list[WordMatch], seen: set[str], match: WordMatch) -> None:
@@ -94,7 +104,14 @@ def _find_korean_compact_matches(variants: dict[str, str]) -> list[WordMatch]:
         if not candidate:
             continue
         for pattern_id, (term, severity) in KOREAN_COMPACT_PATTERNS.items():
-            if term not in candidate or _has_benign_korean_context(candidate, term):
+            term_start = candidate.find(term)
+            while term_start != -1 and _is_inside_benign_korean_substring(
+                candidate,
+                term_start,
+                term_start + len(term),
+            ):
+                term_start = candidate.find(term, term_start + 1)
+            if term_start == -1:
                 continue
             _append_match_once(
                 matches,

--- a/text_filtering/word_matcher.py
+++ b/text_filtering/word_matcher.py
@@ -150,5 +150,5 @@ def detect_bad_word_matches(text: str) -> list[WordMatch]:
     ]
 
 
-def detect_bad_word_match_dicts(text: str) -> list[dict[str, str]]:
+def detect_bad_word_match_dicts(text: str) -> list[dict[str, object]]:
     return [match.to_dict() for match in detect_bad_word_matches(text)]

--- a/text_filtering/word_matcher.py
+++ b/text_filtering/word_matcher.py
@@ -6,6 +6,7 @@ from text_filtering.normalization import normalize_text_variants
 
 
 MatchSeverity = Literal["high", "medium"]
+RuleStage = Literal["strong_candidate", "observe_only"]
 
 BENIGN_KOREAN_SUBSTRINGS = {
     "시발점",
@@ -23,6 +24,15 @@ LATIN_WORD_PATTERNS = {
     "english_shit": ("shit", "high"),
 }
 
+STRONG_RULE_CANDIDATE_PATTERN_IDS = {
+    "korean_sibal",
+    "korean_ssibal",
+    "korean_initial_s_b",
+    "korean_number_sibal",
+    "romanized_sibal",
+    "english_shit",
+}
+
 
 @dataclass(frozen=True)
 class WordMatch:
@@ -31,8 +41,10 @@ class WordMatch:
     normalized: str
     candidate_kind: str
     severity: MatchSeverity
+    rule_stage: RuleStage
+    strong_rule_candidate: bool
 
-    def to_dict(self) -> dict[str, str]:
+    def to_dict(self) -> dict[str, object]:
         return asdict(self)
 
 
@@ -45,6 +57,26 @@ def _append_match_once(matches: list[WordMatch], seen: set[str], match: WordMatc
         return
     seen.add(match.pattern_id)
     matches.append(match)
+
+
+def _make_word_match(
+    *,
+    pattern_id: str,
+    matched_text: str,
+    normalized: str,
+    candidate_kind: str,
+    severity: MatchSeverity,
+) -> WordMatch:
+    is_strong_candidate = pattern_id in STRONG_RULE_CANDIDATE_PATTERN_IDS
+    return WordMatch(
+        pattern_id=pattern_id,
+        matched_text=matched_text,
+        normalized=normalized,
+        candidate_kind=candidate_kind,
+        severity=severity,
+        rule_stage="strong_candidate" if is_strong_candidate else "observe_only",
+        strong_rule_candidate=is_strong_candidate,
+    )
 
 
 def _find_korean_compact_matches(variants: dict[str, str]) -> list[WordMatch]:
@@ -67,7 +99,7 @@ def _find_korean_compact_matches(variants: dict[str, str]) -> list[WordMatch]:
             _append_match_once(
                 matches,
                 seen,
-                WordMatch(
+                _make_word_match(
                     pattern_id=pattern_id,
                     matched_text=term,
                     normalized=candidate,
@@ -98,7 +130,7 @@ def _find_latin_word_matches(variants: dict[str, str]) -> list[WordMatch]:
             _append_match_once(
                 matches,
                 seen,
-                WordMatch(
+                _make_word_match(
                     pattern_id=pattern_id,
                     matched_text=term,
                     normalized=candidate,

--- a/text_filtering/word_matcher.py
+++ b/text_filtering/word_matcher.py
@@ -1,0 +1,122 @@
+import re
+from dataclasses import asdict, dataclass
+from typing import Literal
+
+from text_filtering.normalization import normalize_text_variants
+
+
+MatchSeverity = Literal["high", "medium"]
+
+BENIGN_KOREAN_SUBSTRINGS = {
+    "시발점",
+}
+
+KOREAN_COMPACT_PATTERNS = {
+    "korean_sibal": ("시발", "high"),
+    "korean_ssibal": ("씨발", "high"),
+    "korean_initial_s_b": ("ㅅㅂ", "high"),
+    "korean_number_sibal": ("ㅅㅣ발", "high"),
+}
+
+LATIN_WORD_PATTERNS = {
+    "romanized_sibal": ("sibal", "high"),
+    "english_shit": ("shit", "high"),
+}
+
+
+@dataclass(frozen=True)
+class WordMatch:
+    pattern_id: str
+    matched_text: str
+    normalized: str
+    candidate_kind: str
+    severity: MatchSeverity
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+def _has_benign_korean_context(text: str, term: str) -> bool:
+    return any(benign in text for benign in BENIGN_KOREAN_SUBSTRINGS if term in benign)
+
+
+def _append_match_once(matches: list[WordMatch], seen: set[str], match: WordMatch) -> None:
+    if match.pattern_id in seen:
+        return
+    seen.add(match.pattern_id)
+    matches.append(match)
+
+
+def _find_korean_compact_matches(variants: dict[str, str]) -> list[WordMatch]:
+    matches: list[WordMatch] = []
+    seen: set[str] = set()
+    candidate_kinds = [
+        "compact",
+        "symbol_removed_compact",
+        "korean_number_mapped_compact",
+        "repeated_collapsed_compact",
+    ]
+
+    for candidate_kind in candidate_kinds:
+        candidate = variants.get(candidate_kind, "")
+        if not candidate:
+            continue
+        for pattern_id, (term, severity) in KOREAN_COMPACT_PATTERNS.items():
+            if term not in candidate or _has_benign_korean_context(candidate, term):
+                continue
+            _append_match_once(
+                matches,
+                seen,
+                WordMatch(
+                    pattern_id=pattern_id,
+                    matched_text=term,
+                    normalized=candidate,
+                    candidate_kind=candidate_kind,
+                    severity=severity,
+                ),
+            )
+
+    return matches
+
+
+def _find_latin_word_matches(variants: dict[str, str]) -> list[WordMatch]:
+    matches: list[WordMatch] = []
+    seen: set[str] = set()
+    candidate_kinds = [
+        "lower",
+        "symbol_removed",
+        "latin_number_mapped",
+    ]
+
+    for candidate_kind in candidate_kinds:
+        candidate = variants.get(candidate_kind, "")
+        if not candidate:
+            continue
+        for pattern_id, (term, severity) in LATIN_WORD_PATTERNS.items():
+            if not re.search(rf"(?<![a-z0-9]){re.escape(term)}(?![a-z0-9])", candidate):
+                continue
+            _append_match_once(
+                matches,
+                seen,
+                WordMatch(
+                    pattern_id=pattern_id,
+                    matched_text=term,
+                    normalized=candidate,
+                    candidate_kind=candidate_kind,
+                    severity=severity,
+                ),
+            )
+
+    return matches
+
+
+def detect_bad_word_matches(text: str) -> list[WordMatch]:
+    variants = normalize_text_variants(text)
+    return [
+        *_find_korean_compact_matches(variants),
+        *_find_latin_word_matches(variants),
+    ]
+
+
+def detect_bad_word_match_dicts(text: str) -> list[dict[str, str]]:
+    return [match.to_dict() for match in detect_bad_word_matches(text)]


### PR DESCRIPTION
## 관련 이슈

Closes #140 

## 🎯 배경

- 텍스트 필터링이 띄어쓰기, 특수문자, 반복 문자, 로마자, 숫자 치환 비속어를 놓치는 케이스를 회귀 리포트로 관찰하고 개선 기반을 마련합니다.
- 운영 판정을 즉시 바꾸지 않고 shadow match와 feature flag 기반 strong rule override로 단계적 반영이 가능하도록 합니다.

## 🔍 주요 내용

- 텍스트 필터링 품질 baseline/변형 케이스를 확장했습니다.
- 정규화 helper와 단어 단위 match detector를 추가했습니다.
- 품질 리포트에 shadow match 및 strong rule candidate 지표를 추가했습니다.
- field 응답에 `matches`와 `strong_rule_override` 정보를 backward-compatible하게 추가했습니다.
- `TEXT_FILTER_STRONG_RULE_OVERRIDE` 기본값 OFF flag로 strong rule override를 제어합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 변경 요약(1~3줄)
텍스트 필터링에 정규화 + 단어 수준 워드 매칭 기반의 “강한(Strong) 규칙” 탐지 경로를 추가하고, 리포트/회귀 테스트까지 확장했습니다. `TEXT_FILTER_STRONG_RULE_OVERRIDE` 플래그로만 운영용 오버라이드를 선택적으로 적용하게 했어요(기본 OFF).

## 주요 변경점(불릿 3~7개)
- `text_filtering/normalization.py` 추가: 공백/특수문자 제거, 반복 문자 축약, 한글/숫자·로마자 변형 정규화
- `text_filtering/word_matcher.py` 추가: 단어 단위 매치 탐지(`pattern_id`, 강한 후보 여부, `rule_stage`) 및 증거 형태 반환
- `text_filtering/service.py` 확장: `matches` 및 `strong_rule_override`(enabled/applied/match_count) 응답 필드 추가(기존 필드 호환 유지)
- `TEXT_FILTER_STRONG_RULE_OVERRIDE` 설정 추가/문서화: 환경변수 값에 따라 강한 오버라이드 적용 여부 제어
- 품질 리포트 강화: shadow 매치 결과와 strong-rule 후보 메트릭(카테고리별 집계, baseline 메타데이터/phase 반영)
- 회귀 테스트/케이스 확대: 공백 우회, 특수문자 삽입, 반복 문자, 로마자/숫자 치환, 숫자-변형 욕설 & 오탐 가드까지 커버

## 주의/리스크(있으면 1~3개)
- `TEXT_FILTER_STRONG_RULE_OVERRIDE=1`로 켜면 `has_profanity`가 강한 규칙 후보 기반으로 달라질 수 있어 운영 영향 점검이 필요합니다.
- 정규화 규칙이 늘어나면서 오탐 경계(특히 유사 문자열/영문 혼합) 케이스 검증이 더 중요해졌습니다.

## 다음 액션(있으면 1~3개)
- 플래그 OFF/ON 두 모드로 회귀를 돌려 shadow 지표와 실제 판정 차이를 계속 모니터링하기
- strong-rule 후보 중 오탐 위험이 큰 패턴/케이스를 추가로 보강(가드 케이스·부정 테스트 확대)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->