### PR TITLE
test/text filter shadow variant eval

### DIFF
--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -119,7 +119,7 @@ python tests/regression/timetable/measure_timetable_ocr_baseline.py --profile oc
 - `shadow_strong_rule_candidate_match_count`: feature flag 기반 운영 반영 후보로 분리된 강한 규칙 match 수
 - `shadow_strong_rule_detected_false_negative_count`: 기존 모델이 놓친 케이스 중 강한 규칙 후보가 match 근거를 만든 수
 
-리포트의 `examples` 섹션은 모델 기준 false negative/false positive 샘플과, 그중 shadow detector가 match 근거를 만든 후보를 최대 5개씩 보여줍니다. 샘플 개수는 `--example-limit`로 조정할 수 있습니다.
+리포트의 `examples` 섹션은 모델 기준 false negative/false positive 샘플과, 그중 shadow detector가 match 근거를 만든 후보를 최대 5개씩 보여줍니다. 샘플 개수는 `--example-limit`로 조정할 수 있습니다. 각 샘플은 `shadow_patterns`와 `strong_rule_candidate_patterns`를 함께 기록해서 default-off strong rule 후보 판단에 활용할 수 있게 합니다.
 
 이 스크립트는 `analyze_text_labels()`만 호출하므로 테스트 문장을 `data/bad_text_sample.txt`에 append하지 않습니다. 모델 파일 또는 의존성이 없는 환경에서는 실패 대신 `status: "skipped"` 리포트를 기본 경로에 기록합니다.
 기본 실행은 품질 리포트를 기록하고 종료 코드는 0으로 유지합니다. 품질 실패를 게이트로 쓰려면 `--strict`를 함께 사용합니다.

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -119,6 +119,8 @@ python tests/regression/timetable/measure_timetable_ocr_baseline.py --profile oc
 - `shadow_strong_rule_candidate_match_count`: feature flag 기반 운영 반영 후보로 분리된 강한 규칙 match 수
 - `shadow_strong_rule_detected_false_negative_count`: 기존 모델이 놓친 케이스 중 강한 규칙 후보가 match 근거를 만든 수
 
+리포트의 `examples` 섹션은 모델 기준 false negative/false positive 샘플과, 그중 shadow detector가 match 근거를 만든 후보를 최대 5개씩 보여줍니다. 샘플 개수는 `--example-limit`로 조정할 수 있습니다.
+
 이 스크립트는 `analyze_text_labels()`만 호출하므로 테스트 문장을 `data/bad_text_sample.txt`에 append하지 않습니다. 모델 파일 또는 의존성이 없는 환경에서는 실패 대신 `status: "skipped"` 리포트를 기본 경로에 기록합니다.
 기본 실행은 품질 리포트를 기록하고 종료 코드는 0으로 유지합니다. 품질 실패를 게이트로 쓰려면 `--strict`를 함께 사용합니다.
 

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -111,13 +111,20 @@ python tests/regression/timetable/measure_timetable_ocr_baseline.py --profile oc
 
 - `false_positive_count`: 정상 문장을 비속어로 판정한 케이스 수
 - `false_negative_count`: 비속어 문장을 정상으로 판정한 케이스 수
+- `model_false_positive_count`, `model_false_negative_count`: 기존 모델 판정 기준 오탐/미탐 케이스 수
 - `pass_rate`: 전체 golden case 기대값과 실제 결과가 일치한 비율
 - `ml_filter_pass_rate`: 현재 ML 기반 판정 경로 기준 통과율
 - `rule_endpoint_pass_rate`: 현재 `/text_filter_rule` API 계약의 공유 판정 경로 기준 통과율
 - `shadow_match_count`: 운영 판정에 연결하지 않은 단어 단위 detector match 수
+- `shadow_matched_case_count`: shadow detector가 하나 이상의 match 근거를 만든 케이스 수
 - `shadow_detected_false_negative_count`: 기존 모델이 놓친 비속어 케이스 중 shadow detector가 match 근거를 만든 수
+- `shadow_detected_false_negative_rate`: 기존 모델 미탐 중 shadow detector가 보완 근거를 만든 비율
+- `shadow_false_positive_candidate_count`: 정상 기대 케이스 중 shadow detector가 match 근거를 만든 오탐 후보 수
+- `shadow_false_positive_candidate_rate`: 정상 기대 케이스 중 shadow 오탐 후보 비율
 - `shadow_strong_rule_candidate_match_count`: feature flag 기반 운영 반영 후보로 분리된 강한 규칙 match 수
 - `shadow_strong_rule_detected_false_negative_count`: 기존 모델이 놓친 케이스 중 강한 규칙 후보가 match 근거를 만든 수
+- `shadow_strong_rule_false_positive_candidate_count`: 정상 기대 케이스 중 강한 규칙 후보가 match 근거를 만든 수
+- `by_category`, `shadow_by_category`, `by_pattern_id`: 카테고리와 pattern id별로 모델 미탐, shadow 보완, 오탐 후보를 나눠 보는 집계
 
 리포트의 `examples` 섹션은 모델 기준 false negative/false positive 샘플과, 그중 shadow detector가 match 근거를 만든 후보를 최대 5개씩 보여줍니다. 샘플 개수는 `--example-limit`로 조정할 수 있습니다. 각 샘플은 `shadow_patterns`와 `strong_rule_candidate_patterns`를 함께 기록해서 default-off strong rule 후보 판단에 활용할 수 있게 합니다.
 

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -101,7 +101,7 @@ python tests/regression/timetable/measure_timetable_ocr_baseline.py --profile oc
 
 ### Text Filtering Quality Metrics
 
-`tests/regression/text_filtering/check_text_filter_quality_report.py`는 `tests/regression/text_filtering/text_filter_quality_cases.json`의 케이스를 읽어 기존 텍스트 필터 판정 로직을 평가합니다.
+`tests/regression/text_filtering/check_text_filter_quality_report.py`는 기본적으로 `tests/regression/text_filtering/cases/*.json`의 케이스를 읽어 기존 텍스트 필터 판정 로직을 평가합니다. `--cases`로 기존 단일 JSON 파일도 지정할 수 있습니다.
 현재 케이스 파일의 1차 목적은 단어 단위 shadow 탐지 작업 전에 운영 True/False 및 `has_profanity` 판정 기준선을 고정하는 것입니다.
 `tests/regression/text_filtering/check_text_filter_normalization.py`는 운영 판정과 연결하지 않은 정규화 후보 생성 helper만 검증합니다.
 `tests/regression/text_filtering/check_text_filter_word_matcher.py`는 정규화 후보 기반 단어 단위 match 근거 생성을 검증하며, 운영 API 판정에는 연결하지 않습니다.

--- a/tests/regression/text_filtering/cases/baseline.json
+++ b/tests/regression/text_filtering/cases/baseline.json
@@ -1,0 +1,50 @@
+{
+  "metadata": {
+    "purpose": "baseline",
+    "phase": "1",
+    "description": "Current production text filtering behavior baseline before word-level shadow detection work.",
+    "contract": "Do not change production True/False or has_profanity behavior in this phase."
+  },
+  "cases": [
+    {
+      "id": "clear_korean_profanity_01",
+      "category": "clear_korean_profanity",
+      "text": "이런 씨발 같은 상황은 너무 화가 납니다.",
+      "expected": {
+        "has_profanity": true
+      }
+    },
+    {
+      "id": "normal_sentence_01",
+      "category": "normal_sentence",
+      "text": "오늘 수업 자료를 확인하고 과제를 제출했습니다.",
+      "expected": {
+        "has_profanity": false
+      }
+    },
+    {
+      "id": "normal_sentence_02",
+      "category": "normal_sentence",
+      "text": "동아리 모집 안내를 보고 친구와 함께 신청했습니다.",
+      "expected": {
+        "has_profanity": false
+      }
+    },
+    {
+      "id": "normal_english_sentence_01",
+      "category": "normal_english_sentence",
+      "text": "Please check the class notice before tomorrow.",
+      "expected": {
+        "has_profanity": false
+      }
+    },
+    {
+      "id": "english_profanity_01",
+      "category": "english_profanity",
+      "text": "That was a shit idea.",
+      "expected": {
+        "has_profanity": true
+      }
+    }
+  ]
+}

--- a/tests/regression/text_filtering/cases/english_obfuscation.json
+++ b/tests/regression/text_filtering/cases/english_obfuscation.json
@@ -1,0 +1,26 @@
+{
+  "metadata": {
+    "purpose": "english_obfuscation",
+    "phase": "1",
+    "description": "English profanity variants observed by the report-only shadow matcher.",
+    "contract": "Do not change production True/False or has_profanity behavior in this phase."
+  },
+  "cases": [
+    {
+      "id": "english_variant_obfuscation_01",
+      "category": "english_variant_obfuscation",
+      "text": "That was a sh1t response.",
+      "expected": {
+        "has_profanity": true
+      }
+    },
+    {
+      "id": "romanized_korean_profanity_01",
+      "category": "romanized_korean_profanity",
+      "text": "댓글에 sibal 같은 로마자 욕설을 쓰면 안 됩니다.",
+      "expected": {
+        "has_profanity": true
+      }
+    }
+  ]
+}

--- a/tests/regression/text_filtering/cases/false_positive_guards.json
+++ b/tests/regression/text_filtering/cases/false_positive_guards.json
@@ -1,0 +1,18 @@
+{
+  "metadata": {
+    "purpose": "false_positive_guards",
+    "phase": "1",
+    "description": "Benign sentences that protect against over-broad shadow matching.",
+    "contract": "Do not change production True/False or has_profanity behavior in this phase."
+  },
+  "cases": [
+    {
+      "id": "normal_false_positive_guard_01",
+      "category": "normal_false_positive_guard",
+      "text": "이 논의의 시발점은 수업 공지 내용이었습니다.",
+      "expected": {
+        "has_profanity": false
+      }
+    }
+  ]
+}

--- a/tests/regression/text_filtering/cases/korean_obfuscation.json
+++ b/tests/regression/text_filtering/cases/korean_obfuscation.json
@@ -1,0 +1,58 @@
+{
+  "metadata": {
+    "purpose": "korean_obfuscation",
+    "phase": "1",
+    "description": "Korean spacing, initial-consonant, symbol, repeated-character, and number obfuscation cases.",
+    "contract": "Do not change production True/False or has_profanity behavior in this phase."
+  },
+  "cases": [
+    {
+      "id": "korean_variant_spacing_01",
+      "category": "korean_variant_spacing",
+      "text": "시 발 이라고 띄어 써도 상대에게 불쾌감을 줄 수 있습니다.",
+      "expected": {
+        "has_profanity": true
+      }
+    },
+    {
+      "id": "korean_variant_spacing_02",
+      "category": "korean_variant_spacing",
+      "text": "씨 발처럼 일부러 띄어 쓰는 표현도 필터링 대상입니다.",
+      "expected": {
+        "has_profanity": true
+      }
+    },
+    {
+      "id": "korean_initial_consonant_01",
+      "category": "korean_initial_consonant",
+      "text": "댓글에 ㅅㅂ 같은 초성 욕설을 남기면 안 됩니다.",
+      "expected": {
+        "has_profanity": true
+      }
+    },
+    {
+      "id": "korean_special_character_01",
+      "category": "korean_special_character",
+      "text": "씨@발처럼 특수문자를 끼워 넣은 표현도 제재 대상입니다.",
+      "expected": {
+        "has_profanity": true
+      }
+    },
+    {
+      "id": "korean_repeated_character_01",
+      "category": "korean_repeated_character",
+      "text": "씨이발처럼 글자를 늘려 쓰는 표현도 비속어로 봐야 합니다.",
+      "expected": {
+        "has_profanity": true
+      }
+    },
+    {
+      "id": "korean_number_obfuscation_01",
+      "category": "korean_number_obfuscation",
+      "text": "ㅅ1발처럼 숫자를 섞은 표현도 필터링 대상입니다.",
+      "expected": {
+        "has_profanity": true
+      }
+    }
+  ]
+}

--- a/tests/regression/text_filtering/check_text_filter_quality_report.py
+++ b/tests/regression/text_filtering/check_text_filter_quality_report.py
@@ -358,35 +358,61 @@ def aggregate_metrics(case_results: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _shadow_pattern_ids(result: dict[str, Any]) -> list[str]:
+def _shadow_matches(result: dict[str, Any]) -> list[dict[str, Any]]:
     shadow = result.get("shadow", {})
     matches = shadow.get("matches", []) if isinstance(shadow, dict) else []
+    return [match for match in matches if isinstance(match, dict)]
+
+
+def _shadow_pattern_ids(result: dict[str, Any]) -> list[str]:
+    matches = _shadow_matches(result)
     pattern_ids = {
         str(match.get("pattern_id", "") or "unknown")
         for match in matches
-        if isinstance(match, dict)
+    }
+    return sorted(pattern_ids)
+
+
+def _strong_rule_candidate_pattern_ids(result: dict[str, Any]) -> list[str]:
+    matches = _shadow_matches(result)
+    pattern_ids = {
+        str(match.get("pattern_id", "") or "unknown")
+        for match in matches
+        if match.get("strong_rule_candidate") is True
     }
     return sorted(pattern_ids)
 
 
 def _example_from_result(result: dict[str, Any]) -> dict[str, Any]:
     shadow = result.get("shadow", {})
+    shadow_patterns = _shadow_pattern_ids(result)
+    strong_rule_candidate_patterns = _strong_rule_candidate_pattern_ids(result)
     return {
         "id": result.get("id"),
         "category": result.get("category"),
         "source_file": result.get("source_file"),
         "text": result.get("text"),
+        "errors": result.get("errors", []),
         "expected_has_profanity": result.get("expected", {}).get("has_profanity"),
         "actual_has_profanity": result.get("actual", {}).get("has_profanity"),
         "actual_labels": result.get("actual", {}).get("labels"),
         "shadow_has_match": bool(shadow.get("has_match")) if isinstance(shadow, dict) else False,
-        "shadow_pattern_ids": _shadow_pattern_ids(result),
+        "shadow_patterns": shadow_patterns,
+        "shadow_pattern_ids": shadow_patterns,
+        "strong_rule_candidate_patterns": strong_rule_candidate_patterns,
     }
 
 
-def build_examples(case_results: list[dict[str, Any]], limit: int) -> dict[str, list[dict[str, Any]]]:
+def build_examples(case_results: list[dict[str, Any]], limit: int) -> dict[str, Any]:
     if limit <= 0:
         return {
+            "limit": limit,
+            "counts": {
+                "false_negatives": 0,
+                "false_positives": 0,
+                "shadow_detected_false_negatives": 0,
+                "shadow_false_positive_candidates": 0,
+            },
             "false_negatives_top": [],
             "false_positives_top": [],
             "shadow_detected_false_negatives_top": [],
@@ -416,6 +442,13 @@ def build_examples(case_results: list[dict[str, Any]], limit: int) -> dict[str, 
     ]
 
     return {
+        "limit": limit,
+        "counts": {
+            "false_negatives": len(false_negatives),
+            "false_positives": len(false_positives),
+            "shadow_detected_false_negatives": len(shadow_detected_false_negatives),
+            "shadow_false_positive_candidates": len(shadow_false_positive_candidates),
+        },
         "false_negatives_top": [_example_from_result(result) for result in false_negatives[:limit]],
         "false_positives_top": [_example_from_result(result) for result in false_positives[:limit]],
         "shadow_detected_false_negatives_top": [

--- a/tests/regression/text_filtering/check_text_filter_quality_report.py
+++ b/tests/regression/text_filtering/check_text_filter_quality_report.py
@@ -9,25 +9,63 @@ ROOT_DIR = Path(__file__).resolve().parents[3]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-DEFAULT_CASES_PATH = ROOT_DIR / "tests" / "regression" / "text_filtering" / "text_filter_quality_cases.json"
+DEFAULT_CASES_PATH = ROOT_DIR / "tests" / "regression" / "text_filtering" / "cases"
 DEFAULT_REPORT_PATH = ROOT_DIR / "tests" / "reports" / "text_filtering" / "text_filter_quality_report.json"
 SUITE = "text_filter_quality"
 SERVICE = "text_filtering"
 BASELINE_PHASE = "1"
 
 
+def load_case_payloads(path: Path) -> list[tuple[Path, dict[str, Any]]]:
+    if path.is_dir():
+        case_files = sorted(child for child in path.glob("*.json") if child.is_file())
+        if not case_files:
+            raise ValueError(f"no text filtering case files found in {path}")
+        return [(case_file, json.loads(case_file.read_text(encoding="utf-8"))) for case_file in case_files]
+
+    return [(path, json.loads(path.read_text(encoding="utf-8")))]
+
+
 def load_cases(path: Path) -> list[dict[str, Any]]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    cases = payload.get("cases", [])
-    if not isinstance(cases, list) or not cases:
+    loaded_cases: list[dict[str, Any]] = []
+    for case_file, payload in load_case_payloads(path):
+        resolved_case_file = case_file.resolve()
+        cases = payload.get("cases", [])
+        if not isinstance(cases, list) or not cases:
+            raise ValueError(f"no text filtering cases found in {case_file}")
+        for case in cases:
+            if isinstance(case, dict):
+                loaded_case = dict(case)
+                loaded_case.setdefault("source_file", str(resolved_case_file.relative_to(ROOT_DIR)))
+                loaded_cases.append(loaded_case)
+
+    if not loaded_cases:
         raise ValueError(f"no text filtering cases found in {path}")
-    return cases
+    return loaded_cases
 
 
 def load_case_metadata(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    metadata = payload.get("metadata", {})
-    return metadata if isinstance(metadata, dict) else {}
+    payloads = load_case_payloads(path)
+    if len(payloads) == 1:
+        metadata = payloads[0][1].get("metadata", {})
+        return metadata if isinstance(metadata, dict) else {}
+
+    case_files: list[dict[str, Any]] = []
+    for case_file, payload in payloads:
+        resolved_case_file = case_file.resolve()
+        metadata = payload.get("metadata", {})
+        cases = payload.get("cases", [])
+        case_files.append({
+            "path": str(resolved_case_file.relative_to(ROOT_DIR)),
+            "metadata": metadata if isinstance(metadata, dict) else {},
+            "case_count": len(cases) if isinstance(cases, list) else 0,
+        })
+
+    return {
+        "purpose": "text_filter_shadow_variant_evaluation",
+        "contract": "Do not change production True/False or has_profanity behavior in this phase.",
+        "case_files": case_files,
+    }
 
 
 def validate_cases(cases: list[dict[str, Any]]) -> list[str]:
@@ -169,6 +207,7 @@ def evaluate_case(case: dict[str, Any], text_filter_service) -> dict[str, Any]:
     return {
         "id": case.get("id"),
         "category": case.get("category"),
+        "source_file": case.get("source_file"),
         "text": text,
         "expected": {
             "has_profanity": expected_has_profanity,

--- a/tests/regression/text_filtering/check_text_filter_quality_report.py
+++ b/tests/regression/text_filtering/check_text_filter_quality_report.py
@@ -358,12 +358,84 @@ def aggregate_metrics(case_results: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _shadow_pattern_ids(result: dict[str, Any]) -> list[str]:
+    shadow = result.get("shadow", {})
+    matches = shadow.get("matches", []) if isinstance(shadow, dict) else []
+    pattern_ids = {
+        str(match.get("pattern_id", "") or "unknown")
+        for match in matches
+        if isinstance(match, dict)
+    }
+    return sorted(pattern_ids)
+
+
+def _example_from_result(result: dict[str, Any]) -> dict[str, Any]:
+    shadow = result.get("shadow", {})
+    return {
+        "id": result.get("id"),
+        "category": result.get("category"),
+        "source_file": result.get("source_file"),
+        "text": result.get("text"),
+        "expected_has_profanity": result.get("expected", {}).get("has_profanity"),
+        "actual_has_profanity": result.get("actual", {}).get("has_profanity"),
+        "actual_labels": result.get("actual", {}).get("labels"),
+        "shadow_has_match": bool(shadow.get("has_match")) if isinstance(shadow, dict) else False,
+        "shadow_pattern_ids": _shadow_pattern_ids(result),
+    }
+
+
+def build_examples(case_results: list[dict[str, Any]], limit: int) -> dict[str, list[dict[str, Any]]]:
+    if limit <= 0:
+        return {
+            "false_negatives_top": [],
+            "false_positives_top": [],
+            "shadow_detected_false_negatives_top": [],
+            "shadow_false_positive_candidates_top": [],
+        }
+
+    false_negatives = [
+        result
+        for result in case_results
+        if "false_negative" in result.get("errors", [])
+    ]
+    false_positives = [
+        result
+        for result in case_results
+        if "false_positive" in result.get("errors", [])
+    ]
+    shadow_detected_false_negatives = [
+        result
+        for result in false_negatives
+        if result.get("shadow", {}).get("has_match") is True
+    ]
+    shadow_false_positive_candidates = [
+        result
+        for result in case_results
+        if result.get("expected", {}).get("has_profanity") is False
+        and result.get("shadow", {}).get("has_match") is True
+    ]
+
+    return {
+        "false_negatives_top": [_example_from_result(result) for result in false_negatives[:limit]],
+        "false_positives_top": [_example_from_result(result) for result in false_positives[:limit]],
+        "shadow_detected_false_negatives_top": [
+            _example_from_result(result)
+            for result in shadow_detected_false_negatives[:limit]
+        ],
+        "shadow_false_positive_candidates_top": [
+            _example_from_result(result)
+            for result in shadow_false_positive_candidates[:limit]
+        ],
+    }
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Write a text filtering quality report")
     ap.add_argument("--cases", default=str(DEFAULT_CASES_PATH), help="golden text filtering cases path")
     ap.add_argument("--out", default=str(DEFAULT_REPORT_PATH), help="output report path")
     ap.add_argument("--validate-only", action="store_true", help="validate golden cases without loading the model")
     ap.add_argument("--strict", action="store_true", help="return a non-zero exit code when evaluated cases fail")
+    ap.add_argument("--example-limit", type=int, default=5, help="maximum examples per report examples bucket")
     args = ap.parse_args()
 
     cases_path = Path(args.cases)
@@ -478,6 +550,7 @@ def main() -> int:
         },
         "summary": summary,
         "cases_path": str(cases_path),
+        "examples": build_examples(case_results, args.example_limit),
         "case_results": case_results,
         "notes": [
             "This report calls analyze_text_labels() only, so test cases are not appended to data/bad_text_sample.txt.",

--- a/tests/regression/text_filtering/check_text_filter_quality_report.py
+++ b/tests/regression/text_filtering/check_text_filter_quality_report.py
@@ -105,6 +105,10 @@ def count_cases_by_category(cases: list[dict[str, Any]]) -> dict[str, int]:
     return by_category
 
 
+def rate(numerator: int, denominator: int) -> float:
+    return round(numerator / denominator, 4) if denominator else 0.0
+
+
 def write_report(out_path: Path, output: dict[str, Any]) -> None:
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(output, ensure_ascii=False, indent=2), encoding="utf-8")
@@ -228,6 +232,10 @@ def evaluate_case(case: dict[str, Any], text_filter_service) -> dict[str, Any]:
 
 def aggregate_shadow_metrics(case_results: list[dict[str, Any]]) -> dict[str, Any]:
     total = len(case_results)
+    model_false_negative_count = 0
+    model_false_positive_count = 0
+    normal_case_count = 0
+    profanity_case_count = 0
     shadow_matched_case_count = 0
     shadow_match_count = 0
     shadow_detected_false_negative_count = 0
@@ -239,6 +247,7 @@ def aggregate_shadow_metrics(case_results: list[dict[str, Any]]) -> dict[str, An
     shadow_strong_rule_false_positive_candidate_count = 0
     pattern_counts: dict[str, int] = {}
     strong_rule_pattern_counts: dict[str, int] = {}
+    by_pattern_id: dict[str, dict[str, Any]] = {}
     by_category: dict[str, dict[str, Any]] = {}
 
     for result in case_results:
@@ -252,6 +261,17 @@ def aggregate_shadow_metrics(case_results: list[dict[str, Any]]) -> dict[str, An
         strong_matches = [match for match in matches if match.get("strong_rule_candidate") is True]
         strong_match_count = len(strong_matches)
         has_strong_match = strong_match_count > 0
+        is_model_false_negative = expected_has_profanity and not actual_has_profanity
+        is_model_false_positive = not expected_has_profanity and actual_has_profanity
+
+        if expected_has_profanity:
+            profanity_case_count += 1
+        else:
+            normal_case_count += 1
+        if is_model_false_negative:
+            model_false_negative_count += 1
+        if is_model_false_positive:
+            model_false_positive_count += 1
 
         bucket = by_category.setdefault(
             category,
@@ -264,9 +284,15 @@ def aggregate_shadow_metrics(case_results: list[dict[str, Any]]) -> dict[str, An
                 "shadow_strong_rule_matched": 0,
                 "shadow_strong_rule_false_positive_candidates": 0,
                 "shadow_strong_rule_detected_false_negatives": 0,
+                "model_false_negatives": 0,
+                "model_false_positives": 0,
             },
         )
         bucket["total"] += 1
+        if is_model_false_negative:
+            bucket["model_false_negatives"] += 1
+        if is_model_false_positive:
+            bucket["model_false_positives"] += 1
         if has_match:
             shadow_matched_case_count += 1
             bucket["shadow_matched"] += 1
@@ -277,9 +303,34 @@ def aggregate_shadow_metrics(case_results: list[dict[str, Any]]) -> dict[str, An
         for match in matches:
             pattern_id = str(match.get("pattern_id", "") or "unknown")
             pattern_counts[pattern_id] = pattern_counts.get(pattern_id, 0) + 1
+            pattern_bucket = by_pattern_id.setdefault(
+                pattern_id,
+                {
+                    "match_count": 0,
+                    "matched_case_count": 0,
+                    "profanity_case_count": 0,
+                    "normal_case_count": 0,
+                    "detected_false_negative_count": 0,
+                    "false_positive_candidate_count": 0,
+                    "strong_rule_candidate_match_count": 0,
+                    "strong_rule_candidate_case_count": 0,
+                },
+            )
+            pattern_bucket["match_count"] += 1
+            pattern_bucket["matched_case_count"] += 1
+            if expected_has_profanity:
+                pattern_bucket["profanity_case_count"] += 1
+            else:
+                pattern_bucket["normal_case_count"] += 1
+            if is_model_false_negative:
+                pattern_bucket["detected_false_negative_count"] += 1
+            if not expected_has_profanity:
+                pattern_bucket["false_positive_candidate_count"] += 1
             if match.get("strong_rule_candidate") is True:
                 shadow_strong_rule_candidate_match_count += 1
                 strong_rule_pattern_counts[pattern_id] = strong_rule_pattern_counts.get(pattern_id, 0) + 1
+                pattern_bucket["strong_rule_candidate_match_count"] += 1
+                pattern_bucket["strong_rule_candidate_case_count"] += 1
 
         if has_strong_match:
             shadow_strong_rule_candidate_case_count += 1
@@ -301,24 +352,58 @@ def aggregate_shadow_metrics(case_results: list[dict[str, Any]]) -> dict[str, An
             bucket["shadow_strong_rule_detected_false_negatives"] += 1
 
     for bucket in by_category.values():
-        bucket["shadow_match_rate"] = round(bucket["shadow_matched"] / bucket["total"], 4) if bucket["total"] else 0.0
-        bucket["shadow_strong_rule_match_rate"] = (
-            round(bucket["shadow_strong_rule_matched"] / bucket["total"], 4) if bucket["total"] else 0.0
+        bucket["shadow_match_rate"] = rate(bucket["shadow_matched"], bucket["total"])
+        bucket["shadow_strong_rule_match_rate"] = rate(bucket["shadow_strong_rule_matched"], bucket["total"])
+        bucket["shadow_detected_false_negative_rate"] = rate(
+            bucket["shadow_detected_false_negatives"],
+            bucket["model_false_negatives"],
+        )
+
+    for bucket in by_pattern_id.values():
+        bucket["detected_false_negative_rate"] = rate(
+            bucket["detected_false_negative_count"],
+            model_false_negative_count,
+        )
+        bucket["false_positive_candidate_rate"] = rate(
+            bucket["false_positive_candidate_count"],
+            normal_case_count,
         )
 
     return {
+        "model_false_negative_count": model_false_negative_count,
+        "model_false_positive_count": model_false_positive_count,
+        "normal_case_count": normal_case_count,
+        "profanity_case_count": profanity_case_count,
         "shadow_match_count": shadow_match_count,
         "shadow_matched_case_count": shadow_matched_case_count,
-        "shadow_match_rate": round(shadow_matched_case_count / total, 4) if total else 0.0,
+        "shadow_match_rate": rate(shadow_matched_case_count, total),
         "shadow_true_positive_candidate_count": shadow_true_positive_candidate_count,
         "shadow_false_positive_candidate_count": shadow_false_positive_candidate_count,
         "shadow_detected_false_negative_count": shadow_detected_false_negative_count,
+        "shadow_detected_false_negative_rate": rate(
+            shadow_detected_false_negative_count,
+            model_false_negative_count,
+        ),
+        "shadow_false_positive_candidate_rate": rate(
+            shadow_false_positive_candidate_count,
+            normal_case_count,
+        ),
         "shadow_pattern_counts": pattern_counts,
         "shadow_strong_rule_candidate_match_count": shadow_strong_rule_candidate_match_count,
         "shadow_strong_rule_candidate_case_count": shadow_strong_rule_candidate_case_count,
         "shadow_strong_rule_detected_false_negative_count": shadow_strong_rule_detected_false_negative_count,
         "shadow_strong_rule_false_positive_candidate_count": shadow_strong_rule_false_positive_candidate_count,
+        "shadow_strong_rule_detected_false_negative_rate": rate(
+            shadow_strong_rule_detected_false_negative_count,
+            model_false_negative_count,
+        ),
+        "shadow_strong_rule_false_positive_candidate_rate": rate(
+            shadow_strong_rule_false_positive_candidate_count,
+            normal_case_count,
+        ),
         "shadow_strong_rule_pattern_counts": strong_rule_pattern_counts,
+        "by_pattern_id": by_pattern_id,
+        "shadow_by_pattern_id": by_pattern_id,
         "shadow_by_category": by_category,
     }
 
@@ -335,20 +420,35 @@ def aggregate_metrics(case_results: list[dict[str, Any]]) -> dict[str, Any]:
     by_category: dict[str, dict[str, Any]] = {}
     for result in case_results:
         category = str(result.get("category", "") or "uncategorized")
-        bucket = by_category.setdefault(category, {"total": 0, "passed": 0, "failed": 0})
+        bucket = by_category.setdefault(
+            category,
+            {
+                "total": 0,
+                "passed": 0,
+                "failed": 0,
+                "model_false_negatives": 0,
+                "model_false_positives": 0,
+            },
+        )
         bucket["total"] += 1
         if result["status"] == "passed":
             bucket["passed"] += 1
         else:
             bucket["failed"] += 1
+        if "false_negative" in result.get("errors", []):
+            bucket["model_false_negatives"] += 1
+        if "false_positive" in result.get("errors", []):
+            bucket["model_false_positives"] += 1
 
     for bucket in by_category.values():
-        bucket["pass_rate"] = round(bucket["passed"] / bucket["total"], 4) if bucket["total"] else 0.0
+        bucket["pass_rate"] = rate(bucket["passed"], bucket["total"])
 
-    pass_rate = round(passed / total, 4)
+    pass_rate = rate(passed, total)
     return {
         "false_positive_count": false_positive_count,
         "false_negative_count": false_negative_count,
+        "model_false_positive_count": false_positive_count,
+        "model_false_negative_count": false_negative_count,
         "pass_rate": pass_rate,
         "ml_filter_pass_rate": pass_rate,
         "rule_filter_pass_rate": None,


### PR DESCRIPTION
## 🎯 배경

- 텍스트 필터링 운영 판정은 유지한 채, obfuscation/variant 케이스에서 모델 미탐과 shadow detector 보완 가능성을 관찰할 수 있는 리포트가 필요했습니다.
- detector 자체 수정은 별도 브랜치로 분리하고, 이번 PR은 report-only 평가 기반을 강화합니다.

## 🔍 주요 내용

- 텍스트 필터링 품질 케이스를 baseline, Korean obfuscation, English obfuscation, false-positive guard 파일로 분리
- 품질 리포트가 케이스 디렉터리와 기존 단일 JSON 입력을 모두 지원하도록 확장
- false negative/false positive Top N 및 shadow-detected false negative 예시를 리포트에 추가
- model false negative/positive, shadow coverage rate, pattern/category별 집계 지표 추가
- 텍스트 필터링 회귀 리포트 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 변경 요약
- 텍스트 필터링 회귀 평가를 “리포트 중심”으로 확장했고, 케이스를 baseline/한국어 난독화/영어 난독화/오탐 가드로 분리했습니다.

## 주요 변경점:
  - `tests/regression/text_filtering/cases/` 아래에 케이스 JSON들을 새로 분리 추가했습니다.
  - 리포트가 단일 JSON뿐 아니라 케이스 디렉터리도 읽도록 바뀌었습니다.
  - false negative / false positive 예시와 shadow 감지 예시를 리포트에 포함하도록 확장했습니다.
  - `model_false_negative_count`, `model_false_positive_count`, shadow coverage rate 등 집계 지표를 추가했습니다.
  - 패턴/카테고리별 상세 요약 구조가 더 풍부해졌습니다.
  - 문서(`tests/regression/README.md`)도 새 입력 방식과 지표 설명에 맞게 갱신했습니다.
## 주의/리스크:
  - 리포트 스키마가 넓어져서 기존 소비처가 있으면 호환성 확인이 필요합니다.
  - 케이스가 여러 파일로 분리돼 경로/메타데이터 로딩 방식에 의존하는 부분은 한 번 더 검증하는 게 좋습니다.
## 다음 액션:
  - 리포트 JSON을 읽는 후속 도구나 대시보드가 새 필드를 정상 처리하는지 확인하면 좋습니다.
  - 새 케이스들로 회귀 결과가 의도대로 나오는지 샘플 검증을 해보면 좋습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->