### PR TITLE
fix: improve text filter repeated vowel normalization

### DIFF
--- a/text_filtering/normalization.py
+++ b/text_filtering/normalization.py
@@ -5,6 +5,7 @@ from dataclasses import asdict, dataclass
 WHITESPACE_RE = re.compile(r"\s+")
 REPEATED_CHAR_RE = re.compile(r"(.)\1{2,}")
 KOREAN_VOWEL_EXTENSION_RE = re.compile(r"([가-힣ㄱ-ㅎ])([ㅏ-ㅣ이]){2,}(?=[가-힣ㄱ-ㅎ])")
+KOREAN_SIBAL_VOWEL_EXTENSION_RE = re.compile(r"([시씨])이+(?=발)")
 
 LATIN_NUMBER_MAP = str.maketrans({
     "0": "o",
@@ -37,7 +38,8 @@ def collapse_repeated_characters(text: str) -> str:
 
 
 def collapse_korean_vowel_extensions(text: str) -> str:
-    return KOREAN_VOWEL_EXTENSION_RE.sub(r"\1", text)
+    collapsed = KOREAN_SIBAL_VOWEL_EXTENSION_RE.sub(r"\1", text)
+    return KOREAN_VOWEL_EXTENSION_RE.sub(r"\1", collapsed)
 
 
 def compact_text(text: str) -> str:


### PR DESCRIPTION
## 관련 이슈

Closes #143 

## 🎯 배경

- 텍스트 필터 detector의 shadow 리포트에서 반복 모음 변형(`씨이발`) 케이스가 모델 미탐으로 남고, 기존 detector도 포착하지 못하는 gap이 확인되었습니다.
- 운영 `has_profanity` 판정은 즉시 변경하지 않고, 기존 리포트 기반으로 detector 정규화만 최소 보강합니다.

## 🔍 주요 내용

- `시/씨 + 이... + 발` 형태를 `시발/씨발`로 접는 제한적 정규화 규칙을 추가했습니다.
- 동일 품질 리포트 기준 `shadow_detected_false_negative_count`가 `5 -> 6`으로 개선되었습니다.
- `shadow_false_positive_candidate_count`는 `0`으로 유지되었습니다.
- Docker, 의존성, 환경변수, 모델 아티팩트는 변경하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### 변경 요약
반복 모음이 포함된 `시발/씨발` 변형을 정상화해 텍스트 필터 탐지 누락을 줄였습니다. 운영 API 동작과 오탐 후보 수는 그대로 유지됩니다.

### 주요 변경점
- `시/씨 + 모음 + 발` 전용 정규식 추가
- 반복 모음 변형을 단계적으로 치환하도록 정규화 로직 개선
- `씨이발` 등 변형 탐지 지원
- `has_profanity` 반환 동작 및 API 계약 유지
- 누락 탐지 건수 5→6, 오탐 후보 0건 유지

### 다음 액션
- 관련 탐지 회귀 테스트 및 품질 리포트 결과 확인
- 새로 탐지된 사례를 검토

<!-- end of auto-generated comment: release notes by coderabbit.ai -->