### PR TITLE
ci: validate arm64 docker container builds

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -1,0 +1,95 @@
+name: Docker Build Validation
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-container-build:
+    name: Validate ${{ matrix.service }} ARM64 image
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: main-api
+            dockerfile: Dockerfile
+            image: dongsooop-main-api:ci-validation
+            port: "8888/tcp"
+            command: "main:app"
+          - service: chatbot-api
+            dockerfile: Dockerfiles_oss
+            image: dongsooop-chatbot-api:ci-validation
+            port: "8010/tcp"
+            command: "app_oss_main:app"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Prepare CI-only Docker inputs
+        run: |
+          mkdir -p model/my_electra_finetuned model/artifacts
+          touch model/my_electra_finetuned/.ci-placeholder
+          touch model/artifacts/.ci-placeholder
+          : > .env
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build CI-only ARM64 image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/arm64
+          load: true
+          push: false
+          tags: ${{ matrix.image }}
+          cache-from: type=gha,scope=${{ matrix.service }}-docker-validation
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}-docker-validation
+          provenance: false
+
+      - name: Inspect image and create container
+        env:
+          IMAGE: ${{ matrix.image }}
+          EXPECTED_PORT: ${{ matrix.port }}
+          EXPECTED_COMMAND: ${{ matrix.command }}
+          CONTAINER_NAME: ${{ matrix.service }}-ci-validation
+        run: |
+          test "$(docker image inspect --format '{{.Architecture}}' "$IMAGE")" = "arm64"
+          docker image inspect --format '{{json .Config.Cmd}}' "$IMAGE" | grep -F "$EXPECTED_COMMAND"
+          docker image inspect --format '{{json .Config.ExposedPorts}}' "$IMAGE" | grep -F "$EXPECTED_PORT"
+          docker create --name "$CONTAINER_NAME" "$IMAGE"
+          test "$(docker inspect --format '{{.State.Status}}' "$CONTAINER_NAME")" = "created"
+
+      - name: Write validation summary
+        if: always()
+        env:
+          SERVICE: ${{ matrix.service }}
+          DOCKERFILE: ${{ matrix.dockerfile }}
+        run: |
+          {
+            echo "## Docker Build Validation: $SERVICE"
+            echo ""
+            echo "- Dockerfile: \`$DOCKERFILE\`"
+            echo "- Platform: \`linux/arm64\`"
+            echo "- Validation scope: image build, command/port inspection, container creation"
+            echo "- Model and RAG inputs: CI-only placeholders"
+            echo "- Image publication: disabled"
+            echo ""
+            echo "This check does not start the application or validate model, RAG, database, Ollama, or external API behavior."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -37,9 +37,21 @@ jobs:
 
       - name: Prepare CI-only Docker inputs
         run: |
-          mkdir -p model/my_electra_finetuned model/artifacts
+          mkdir -p \
+            model/my_electra_finetuned \
+            model/artifacts \
+            data/sub_model_data \
+            data/school_info/old_data \
+            data/rule_book
           touch model/my_electra_finetuned/.ci-placeholder
           touch model/artifacts/.ci-placeholder
+          touch data/sub_model_data/.ci-placeholder
+          touch data/rule_book/.ci-placeholder
+          touch data/bad_text_sample.txt
+          touch data/eng_bad_text.txt
+          touch data/department.txt
+          touch data/school_info/old_data/dmu_documents_cleaned.json
+          touch requirements.txt requirements_oss.txt
           : > .env
 
       - name: Set up QEMU
@@ -89,6 +101,7 @@ jobs:
             echo "- Platform: \`linux/arm64\`"
             echo "- Validation scope: image build, command/port inspection, container creation"
             echo "- Model and RAG inputs: CI-only placeholders"
+            echo "- Python dependency manifests: CI-only empty placeholders; dependency installation is not validated"
             echo "- Image publication: disabled"
             echo ""
             echo "This check does not start the application or validate model, RAG, database, Ollama, or external API behavior."


### PR DESCRIPTION
## 🎯 배경

- 실제 모델과 RAG 데이터를 포함한 ARM64 Docker 이미지를 로컬에서 빌드하기 전에 Docker 구성 오류를 PR 단계에서 확인하기 위한 작업입니다.
- 비공개 모델과 데이터를 GitHub에 업로드하지 않고 두 서비스의 이미지 구조와 컨테이너 생성 가능 여부만 검증합니다.

## 🔍 주요 내용

- `main` 대상 PR에서 실행되는 Docker build validation workflow를 추가했습니다.
- main-api와 chatbot-api의 `linux/arm64` 이미지를 병렬로 빌드하도록 구성했습니다.
- CI 전용 placeholder를 사용하며 이미지는 외부 registry나 artifact로 공개하지 않습니다.
- 이미지 architecture, 실행 명령, 노출 포트를 검사하고 `docker create` 성공 여부를 확인합니다.
- 모델 로딩, RAG 데이터, 외부 API, DB 및 실제 애플리케이션 startup은 검증 범위에서 제외했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- 변경 요약  
  PR의 `main` 대상 ARM64 Docker 이미지 빌드 검증 워크플로우를 추가했습니다. `main-api`와 `chatbot-api` 이미지를 병렬 빌드하고 기본 설정을 자동 검증합니다.

- 주요 변경점
  - PR 및 수동 실행 시 Docker 검증 수행
  - CI 전용 placeholder와 더미 입력 사용
  - 이미지 아키텍처, CMD, 노출 포트 검증
  - `docker create` 성공 및 컨테이너 상태 확인
  - 이미지를 레지스트리에 업로드하지 않음
  - 모델, RAG, DB, 외부 API, 실제 애플리케이션 실행은 검증 대상에서 제외

- 주의/리스크
  - 실제 서비스 실행이나 모델·외부 의존성 연동까지 검증하지는 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->